### PR TITLE
Combat Skill Levels + Some automation based on phase/turn.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Fixed issue when deleteting combatant in Combat Traker before combatant begins.
 - At Post-Segment-12 all active combatants Take a Recovery.
 - Stun status is cleared at the beginning of phase.
+- Initial Combat Skill Levels (CSL) support. [#166](https://github.com/dmdorman/hero6e-foundryvtt/issues/166)
 
 # Version 3.0.5
 - Initial DRAIN support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Version 3.0.6
+- Fixed issue when deleteting combatant in Combat Traker before combatant begins.
+- At Post-Segment-12 all active combatants Take a Recovery.
 
 # Version 3.0.5
 - Initial DRAIN support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 - Fixed issue when deleteting combatant in Combat Traker before combatant begins.
 - At Post-Segment-12 all active combatants Take a Recovery.
 - Stun status is cleared at the beginning of phase.
-- Initial Combat Skill Levels (CSL) support. [#166](https://github.com/dmdorman/hero6e-foundryvtt/issues/166)
+- Initial Combat Skill Levels (CSL) support.  OCV is added to attacks.  Simple +1DC. DCV (like all DCV modifiers) is shown but not currently implemented. [#166](https://github.com/dmdorman/hero6e-foundryvtt/issues/166)
 
 # Version 3.0.5
 - Initial DRAIN support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Version 3.0.6
+
 # Version 3.0.5
 - Initial DRAIN support.
 - Changing PC/NPC actor type moved to sheet header.  Also can be changed in the context menu of the actor sidebar. Fixes [#170](https://github.com/dmdorman/hero6e-foundryvtt/issues/170).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Version 3.0.6
 - Fixed issue when deleteting combatant in Combat Traker before combatant begins.
 - At Post-Segment-12 all active combatants Take a Recovery.
+- Stun status is cleared at the beginning of phase.
 
 # Version 3.0.5
 - Initial DRAIN support.

--- a/css/herosystem6e.css
+++ b/css/herosystem6e.css
@@ -775,3 +775,8 @@ div.item-chat {
   color: darkgreen;
   font-weight: 100;
 }
+
+div.csl-attack-list ul {
+  list-style-type: none;
+  padding: 0;
+}

--- a/module/actor/actor-sidebar-sheet.js
+++ b/module/actor/actor-sidebar-sheet.js
@@ -548,6 +548,7 @@ export class HeroSystem6eActorSidebarSheet extends ActorSheet {
         }
 
         this.options.itemFilters.power = expandedData.itemFilters.power
+        this.options.itemFilters.skill = expandedData.itemFilters.skill
 
         await this.actor.update(expandedData)
 

--- a/module/actor/actor-sidebar-sheet.js
+++ b/module/actor/actor-sidebar-sheet.js
@@ -691,56 +691,57 @@ export class HeroSystem6eActorSidebarSheet extends ActorSheet {
 
 
     async _onRecovery(event) {
-        const chars = this.actor.system.characteristics
+        this.actor.TakeRecovery(true)
+//         const chars = this.actor.system.characteristics
 
-        // Shouldn't happen, but you never know
-        if (isNaN(parseInt(chars.stun.value))) {
-            chars.stun.value = 0
-        }
-        if (isNaN(parseInt(chars.end.value))) {
-            chars.end.value = 0
-        }
+//         // Shouldn't happen, but you never know
+//         if (isNaN(parseInt(chars.stun.value))) {
+//             chars.stun.value = 0
+//         }
+//         if (isNaN(parseInt(chars.end.value))) {
+//             chars.end.value = 0
+//         }
 
-        let newStun = parseInt(chars.stun.value) + parseInt(chars.rec.value)
-        let newEnd = parseInt(chars.end.value) + parseInt(chars.rec.value)
+//         let newStun = parseInt(chars.stun.value) + parseInt(chars.rec.value)
+//         let newEnd = parseInt(chars.end.value) + parseInt(chars.rec.value)
 
 
 
-        if (newStun > chars.stun.max) {
-            newStun = Math.max(chars.stun.max, parseInt(chars.stun.value)) // possible > MAX (which is OKish)
-        }
-        let deltaStun = newStun - parseInt(chars.stun.value)
+//         if (newStun > chars.stun.max) {
+//             newStun = Math.max(chars.stun.max, parseInt(chars.stun.value)) // possible > MAX (which is OKish)
+//         }
+//         let deltaStun = newStun - parseInt(chars.stun.value)
 
-        if (newEnd > chars.end.max) {
-            newEnd = Math.max(chars.end.max, parseInt(chars.end.value)) // possible > MAX (which is OKish)
-        }
-        let deltaEnd = newEnd - parseInt(chars.end.value)
+//         if (newEnd > chars.end.max) {
+//             newEnd = Math.max(chars.end.max, parseInt(chars.end.value)) // possible > MAX (which is OKish)
+//         }
+//         let deltaEnd = newEnd - parseInt(chars.end.value)
 
-        await this.actor.update({
-            'system.characteristics.stun.value': newStun,
-            'system.characteristics.end.value': newEnd
-        })
+//         await this.actor.update({
+//             'system.characteristics.stun.value': newStun,
+//             'system.characteristics.end.value': newEnd
+//         })
 
-        let token = this.actor.token
-        let speaker = ChatMessage.getSpeaker({ actor: this.actor, token })
-        speaker["alias"] = this.actor.name
+//         let token = this.actor.token
+//         let speaker = ChatMessage.getSpeaker({ actor: this.actor, token })
+//         speaker["alias"] = this.actor.name
 
-        const chatData = {
-            user: game.user._id,
-            type: CONST.CHAT_MESSAGE_TYPES.OTHER,
-            content: this.actor.name + ` <span title="
-Recovering is a Full Phase Action and occurs at the end of
-the Segment (after all other characters who have a Phase that
-Segment have acted). A character who Recovers during a Phase
-may do nothing else. He cannot even maintain a Constant Power
-or perform Actions that cost no END or take no time. However,
-he may take Zero Phase Actions at the beginning of his Phase
-to turn off Powers, and Persistent Powers that don't cost END
-remain in effect."><i>Takes a Recovery</i></span>, gaining ${deltaEnd} endurance and ${deltaStun} stun.`,
-            speaker: speaker
-        }
+//         const chatData = {
+//             user: game.user._id,
+//             type: CONST.CHAT_MESSAGE_TYPES.OTHER,
+//             content: this.actor.name + ` <span title="
+// Recovering is a Full Phase Action and occurs at the end of
+// the Segment (after all other characters who have a Phase that
+// Segment have acted). A character who Recovers during a Phase
+// may do nothing else. He cannot even maintain a Constant Power
+// or perform Actions that cost no END or take no time. However,
+// he may take Zero Phase Actions at the beginning of his Phase
+// to turn off Powers, and Persistent Powers that don't cost END
+// remain in effect."><i>Takes a Recovery</i></span>, gaining ${deltaEnd} endurance and ${deltaStun} stun.`,
+//             speaker: speaker
+//         }
 
-        return ChatMessage.create(chatData)
+//         return ChatMessage.create(chatData)
     }
 
     _onPresenseAttack(event) {

--- a/module/actor/actor-sidebar-sheet.js
+++ b/module/actor/actor-sidebar-sheet.js
@@ -7,6 +7,7 @@ import { RoundFavorPlayerDown } from "../utility/round.js"
 import { HEROSYS } from '../herosystem6e.js';
 import { onManageActiveEffect } from '../utility/effects.js'
 import { getPowerInfo } from '../utility/util.js'
+import { CombatSkillLevelsForAttack, convertToDcFromItem, convertFromDC } from '../utility/damage.js';
 
 export class HeroSystem6eActorSidebarSheet extends ActorSheet {
 
@@ -96,65 +97,70 @@ export class HeroSystem6eActorSidebarSheet extends ActorSheet {
             // Endurance
             item.system.endEstimate = item.system.end || 0
 
+            // Combat Skill Levels
+            const csl = CombatSkillLevelsForAttack(item)
+
             // Damage
             if (item.type == 'attack' || item.system.subType == 'attack') {
 
-                // Convert dice to pips
-                let pips = item.system.dice * 3;
-                switch (item.system.extraDice) {
-                    case 'pip':
-                        pips += 1;
-                        break
-                    case 'half':
-                        pips += 2;
-                        break
-                }
+                let dc = convertToDcFromItem(item);
 
-                // Add in STR
-                if (item.system.usesStrength) {
-                    let str = data.actor.system.characteristics.str.value
-                    let str5 = Math.floor(str / 5)
-                    if (item.system.killing) {
-                        pips += str5
-                    } else {
-                        pips += str5 * 3
-                    }
+                // // Convert dice to pips
+                // let pips = item.system.dice * 3;
+                // switch (item.system.extraDice) {
+                //     case 'pip':
+                //         pips += 1;
+                //         break
+                //     case 'half':
+                //         pips += 2;
+                //         break
+                // }
 
-                    // Endurance
-                    let strEnd = Math.max(1, Math.round(str / 10))
+                // // Add in STR
+                // if (item.system.usesStrength) {
+                //     let str = data.actor.system.characteristics.str.value
+                //     let str5 = Math.floor(str / 5)
+                //     if (item.system.killing) {
+                //         pips += str5
+                //     } else {
+                //         pips += str5 * 3
+                //     }
 
-                    if (Number.isInteger(item.system.endEstimate)) {
-                        item.system.endEstimate += strEnd
-                    }
+                //     // Endurance
+                //     let strEnd = Math.max(1, Math.round(str / 10))
 
-                }
+                //     if (Number.isInteger(item.system.endEstimate)) {
+                //         item.system.endEstimate += strEnd
+                //     }
 
-                // Add in TK
-                if (item.system.usesTk) {
+                // }
 
-                    let tkItems = data.actor.items.filter(o => o.system.rules == "TELEKINESIS");
-                    let str = 0
-                    for (const item of tkItems) {
-                        str += parseInt(item.system.LEVELS.value) || 0
-                    }
-                    let str5 = Math.floor(str / 5)
-                    if (item.system.killing) {
-                        pips += str5
-                    } else {
-                        pips += str5 * 3
-                    }
+                // // Add in TK
+                // if (item.system.usesTk) {
 
-                    // Endurance
-                    let strEnd = Math.max(1, Math.round(str / 10))
-                    item.system.endEstimate += strEnd
-                }
+                //     let tkItems = data.actor.items.filter(o => o.system.rules == "TELEKINESIS");
+                //     let str = 0
+                //     for (const item of tkItems) {
+                //         str += parseInt(item.system.LEVELS.value) || 0
+                //     }
+                //     let str5 = Math.floor(str / 5)
+                //     if (item.system.killing) {
+                //         pips += str5
+                //     } else {
+                //         pips += str5 * 3
+                //     }
 
-                // Convert pips to DICE
-                let fullDice = Math.floor(pips / 3)
-                let extraDice = pips - fullDice * 3
+                //     // Endurance
+                //     let strEnd = Math.max(1, Math.round(str / 10))
+                //     item.system.endEstimate += strEnd
+                // }
+
+                // // Convert pips to DICE
+                // let fullDice = Math.floor(pips / 3)
+                // let extraDice = pips - fullDice * 3
 
                 // text descrdiption of damage
-                item.system.damage = fullDice
+                item.system.damage = convertFromDC(item, dc)  /*fullDice
                 switch (extraDice) {
                     case 0:
                         item.system.damage += 'D6'
@@ -165,19 +171,22 @@ export class HeroSystem6eActorSidebarSheet extends ActorSheet {
                     case 2:
                         item.system.damage += '.5D6'
                         break
-                }
+                }*/
                 if (item.system.killing) {
                     item.system.damage += 'K'
                 } else {
                     item.system.damage += 'N'
                 }
 
+
+
+
                 // Signed OCV and DCV
                 if (item.system.ocv != undefined) {
-                    item.system.ocv = ("+" + parseInt(item.system.ocv)).replace("+-", "-")
+                    item.system.ocv = ("+" + (parseInt(item.system.ocv) + parseInt(csl.ocv))).replace("+-", "-")
                 }
                 if (item.system.dcv != undefined) {
-                    item.system.dcv = ("+" + parseInt(item.system.dcv)).replace("+-", "-")
+                    item.system.dcv = ("+" + (parseInt(item.system.dcv) + parseInt(csl.dcv))).replace("+-", "-")
                 }
 
 
@@ -218,14 +227,13 @@ export class HeroSystem6eActorSidebarSheet extends ActorSheet {
                 SkillRollUpdateValue(item)
             }
 
-            if (!item.system.endEstimate && item.name == "Mental Blast")
-            {
+            if (!item.system.endEstimate && item.name == "Mental Blast") {
                 console.log(item)
             }
 
             items.push(item)
         }
-        
+
         // Sort attacks
         // Sorting is tricky and not done at the moment.
         // Sorting just the attacks may sort powers as well, which can mess up frameworks.
@@ -483,7 +491,7 @@ export class HeroSystem6eActorSidebarSheet extends ActorSheet {
         data.defense = defense
 
         // Get all applicable effects (from actor and all items)
-        data.allApplicableEffects = Array.from(this.actor.allApplicableEffects()).sort( (a, b) => a.name.localeCompare(b.name))
+        data.allApplicableEffects = Array.from(this.actor.allApplicableEffects()).sort((a, b) => a.name.localeCompare(b.name))
 
         return data
     }
@@ -693,56 +701,56 @@ export class HeroSystem6eActorSidebarSheet extends ActorSheet {
 
     async _onRecovery(event) {
         this.actor.TakeRecovery(true)
-//         const chars = this.actor.system.characteristics
+        //         const chars = this.actor.system.characteristics
 
-//         // Shouldn't happen, but you never know
-//         if (isNaN(parseInt(chars.stun.value))) {
-//             chars.stun.value = 0
-//         }
-//         if (isNaN(parseInt(chars.end.value))) {
-//             chars.end.value = 0
-//         }
+        //         // Shouldn't happen, but you never know
+        //         if (isNaN(parseInt(chars.stun.value))) {
+        //             chars.stun.value = 0
+        //         }
+        //         if (isNaN(parseInt(chars.end.value))) {
+        //             chars.end.value = 0
+        //         }
 
-//         let newStun = parseInt(chars.stun.value) + parseInt(chars.rec.value)
-//         let newEnd = parseInt(chars.end.value) + parseInt(chars.rec.value)
+        //         let newStun = parseInt(chars.stun.value) + parseInt(chars.rec.value)
+        //         let newEnd = parseInt(chars.end.value) + parseInt(chars.rec.value)
 
 
 
-//         if (newStun > chars.stun.max) {
-//             newStun = Math.max(chars.stun.max, parseInt(chars.stun.value)) // possible > MAX (which is OKish)
-//         }
-//         let deltaStun = newStun - parseInt(chars.stun.value)
+        //         if (newStun > chars.stun.max) {
+        //             newStun = Math.max(chars.stun.max, parseInt(chars.stun.value)) // possible > MAX (which is OKish)
+        //         }
+        //         let deltaStun = newStun - parseInt(chars.stun.value)
 
-//         if (newEnd > chars.end.max) {
-//             newEnd = Math.max(chars.end.max, parseInt(chars.end.value)) // possible > MAX (which is OKish)
-//         }
-//         let deltaEnd = newEnd - parseInt(chars.end.value)
+        //         if (newEnd > chars.end.max) {
+        //             newEnd = Math.max(chars.end.max, parseInt(chars.end.value)) // possible > MAX (which is OKish)
+        //         }
+        //         let deltaEnd = newEnd - parseInt(chars.end.value)
 
-//         await this.actor.update({
-//             'system.characteristics.stun.value': newStun,
-//             'system.characteristics.end.value': newEnd
-//         })
+        //         await this.actor.update({
+        //             'system.characteristics.stun.value': newStun,
+        //             'system.characteristics.end.value': newEnd
+        //         })
 
-//         let token = this.actor.token
-//         let speaker = ChatMessage.getSpeaker({ actor: this.actor, token })
-//         speaker["alias"] = this.actor.name
+        //         let token = this.actor.token
+        //         let speaker = ChatMessage.getSpeaker({ actor: this.actor, token })
+        //         speaker["alias"] = this.actor.name
 
-//         const chatData = {
-//             user: game.user._id,
-//             type: CONST.CHAT_MESSAGE_TYPES.OTHER,
-//             content: this.actor.name + ` <span title="
-// Recovering is a Full Phase Action and occurs at the end of
-// the Segment (after all other characters who have a Phase that
-// Segment have acted). A character who Recovers during a Phase
-// may do nothing else. He cannot even maintain a Constant Power
-// or perform Actions that cost no END or take no time. However,
-// he may take Zero Phase Actions at the beginning of his Phase
-// to turn off Powers, and Persistent Powers that don't cost END
-// remain in effect."><i>Takes a Recovery</i></span>, gaining ${deltaEnd} endurance and ${deltaStun} stun.`,
-//             speaker: speaker
-//         }
+        //         const chatData = {
+        //             user: game.user._id,
+        //             type: CONST.CHAT_MESSAGE_TYPES.OTHER,
+        //             content: this.actor.name + ` <span title="
+        // Recovering is a Full Phase Action and occurs at the end of
+        // the Segment (after all other characters who have a Phase that
+        // Segment have acted). A character who Recovers during a Phase
+        // may do nothing else. He cannot even maintain a Constant Power
+        // or perform Actions that cost no END or take no time. However,
+        // he may take Zero Phase Actions at the beginning of his Phase
+        // to turn off Powers, and Persistent Powers that don't cost END
+        // remain in effect."><i>Takes a Recovery</i></span>, gaining ${deltaEnd} endurance and ${deltaStun} stun.`,
+        //             speaker: speaker
+        //         }
 
-//         return ChatMessage.create(chatData)
+        //         return ChatMessage.create(chatData)
     }
 
     _onPresenseAttack(event) {

--- a/module/combat.js
+++ b/module/combat.js
@@ -436,10 +436,31 @@ export class HeroSystem6eCombat extends Combat {
     // TODO: Replace with PostSegment12 activities.
     // Such as automatic recovery
     async PostSegment12() {
+
+
+        // POST-SEGMENT 12 RECOVERY
+        // After Segment 12 each Turn, all characters (except those deeply
+        // unconscious or holding their breath) get a free Post-Segment 12
+        // Recovery. This includes Stunned characters, although the Post-
+        // Segment 12 Recovery does not eliminate the Stunned condition.
+
+        const automation = game.settings.get("hero6efoundryvttv2", "automation");
+
+        let content = `Post-Segment 12 (Turn ${this.round - 1})`;
+        content += '<ul>'
+        for (let combatant of this.combatants.filter(o => !o.defeated)) {
+            const actor = combatant.actor;
+
+            // Make sure we have automation enabled
+            if ((automation === "all") || (automation === "npcOnly" && actor.type == 'npc') || (automation === "pcEndOnly" && actor.type === 'pc')) {
+                content += '<li>' + await combatant.actor.TakeRecovery(false) + '</li>'
+            }
+        }
+        content += '</ul>'
         const chatData = {
             user: game.user._id,
             type: CONST.CHAT_MESSAGE_TYPES.OTHER,
-            content: `Post-Segment 12`,
+            content: content,
         }
 
         return ChatMessage.create(chatData)

--- a/module/combat.js
+++ b/module/combat.js
@@ -78,7 +78,7 @@ export class HeroSystem6eCombat extends Combat {
 
             // Lightning Reflexes
             const actor = game.actors.get(combatant.actorId);
-            const item = actor.items.find(o => o.system.XMLID === "LIGHTNING_REFLEXES_ALL"  || o.system.XMLID === "LIGHTNING_REFLEXES_SINGLE");
+            const item = actor.items.find(o => o.system.XMLID === "LIGHTNING_REFLEXES_ALL" || o.system.XMLID === "LIGHTNING_REFLEXES_SINGLE");
             if (item) {
                 const levels = item.system.LEVELS?.value || item.system.LEVELS || item.system.levels || item.system.other.levels || 0
                 const lightning_reflex_initiative = combatant.initiative + parseInt(levels);
@@ -294,8 +294,11 @@ export class HeroSystem6eCombat extends Combat {
         // Find the expected new active turn
         let activeTurn = this.turns.indexOf(current)
 
+
+
+
         // Advance activeTurn if it has a null turn value (about to be deleted).
-        while (activeTurn < this.turns.length && this.turns[activeTurn].turn === null) {
+        while (activeTurn > -1 && activeTurn < this.turns.length && this.turns[activeTurn].turn === null) {
             activeTurn++;
         }
         activeTurn = this.turns[activeTurn]?.turn || activeTurn;
@@ -306,9 +309,13 @@ export class HeroSystem6eCombat extends Combat {
         // Setup turns in segment fashion
         this.setupTurns();
 
-        // There is an edge case where the last combatant of the round is deleted.
-        activeTurn = Math.clamped(activeTurn, 0, this.turns.length - 1);
-        await this.update({ turn: activeTurn });
+        // If activeTurn == -1 then combat has not begun
+        if (activeTurn > -1) {
+            // There is an edge case where the last combatant of the round is deleted.
+            activeTurn = Math.clamped(activeTurn, 0, this.turns.length - 1);
+            await this.update({ turn: activeTurn });
+
+        }
 
         // Render the collection
         if (this.active) this.collection.render();
@@ -428,7 +435,7 @@ export class HeroSystem6eCombat extends Combat {
 
     // TODO: Replace with PostSegment12 activities.
     // Such as automatic recovery
-    async PostSegment12 () {
+    async PostSegment12() {
         const chatData = {
             user: game.user._id,
             type: CONST.CHAT_MESSAGE_TYPES.OTHER,
@@ -500,8 +507,7 @@ export class HeroSystem6eCombat extends Combat {
             round = 0;
             turn = null
         }
-        if (round == 0)
-        {
+        if (round == 0) {
             turn = null;
         }
 

--- a/module/combat.js
+++ b/module/combat.js
@@ -1,5 +1,6 @@
 import { HERO } from "./config.js";
 import { HEROSYS } from "./herosystem6e.js";
+import { onActiveEffectToggle } from "./utility/effects.js"
 
 export class HeroSystem6eCombat extends Combat {
     constructor(data, context) {
@@ -412,9 +413,51 @@ export class HeroSystem6eCombat extends Combat {
     * @returns {Promise<void>}
     * @protected
     */
-    _onStartTurn(combatant) {
+    async _onStartTurn(combatant) {
         //console.log("_onStartTurn", combatant.name)
-        super._onStartTurn(combatant)
+        await super._onStartTurn(combatant)
+
+        // STUNNING
+        // The character remains Stunned and can take no
+        // Actions (not even Aborting to a defensive action) until his next
+        // Phase.
+
+
+        if (combatant.actor.statuses.has('stunned')) {
+            const effect = combatant.actor.effects.contents.find(o => o.statuses.has('stunned'))
+            console.log(effect);
+            await effect.delete();
+
+            let content = `${combatant.actor.name} recovers from being stunned.`
+            const token = combatant.token
+            const speaker = ChatMessage.getSpeaker({ actor: combatant.actor, token })
+            speaker["alias"] = combatant.actor.name
+            const chatData = {
+                user: game.user._id,
+                type: CONST.CHAT_MESSAGE_TYPES.OTHER,
+                content: content,
+                //speaker: speaker
+            }
+
+            await ChatMessage.create(chatData)
+
+
+        }
+
+    }
+
+    /**
+     * A workflow that occurs at the end of each Combat Turn.
+     * This workflow occurs after the Combat document update, prior round information exists in this.previous.
+     * This can be overridden to implement system-specific combat tracking behaviors.
+     * This method only executes for one designated GM user. If no GM users are present this method will not be called.
+     * @param {Combatant} combatant     The Combatant whose turn just ended
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async _onEndTurn(combatant) {
+        //console.log("_onStartTurn", combatant.name)
+        super._onEndTurn(combatant)
 
     }
 

--- a/module/combat.js
+++ b/module/combat.js
@@ -425,7 +425,9 @@ export class HeroSystem6eCombat extends Combat {
 
         if (combatant.actor.statuses.has('stunned')) {
             const effect = combatant.actor.effects.contents.find(o => o.statuses.has('stunned'))
-            console.log(effect);
+
+            // At beginning of combat if stunned effect is deleted a console error is generated.
+            // This would be extremetly unusual as characters typically don't start combat stunned.
             await effect.delete();
 
             let content = `${combatant.actor.name} recovers from being stunned.`

--- a/module/combat.js
+++ b/module/combat.js
@@ -78,11 +78,11 @@ export class HeroSystem6eCombat extends Combat {
 
             // Lightning Reflexes
             const actor = game.actors.get(combatant.actorId);
-            const item = actor.items.find(o => o.system.XMLID === "LIGHTNING_REFLEXES_ALL");
+            const item = actor.items.find(o => o.system.XMLID === "LIGHTNING_REFLEXES_ALL"  || o.system.XMLID === "LIGHTNING_REFLEXES_SINGLE");
             if (item) {
                 const levels = item.system.LEVELS?.value || item.system.LEVELS || item.system.levels || item.system.other.levels || 0
                 const lightning_reflex_initiative = combatant.initiative + parseInt(levels);
-                const alias = item.system.OPTION_ALIAS || item.system.other.option_alias || 'None'
+                const alias = item.system.OPTION_ALIAS || item.system.INPUT || 'All Actions'
                 const lightning_reflex_alias = '(' + alias + ')'
 
                 const combatantLR = new HeroCombatant(combatant)

--- a/module/config.js
+++ b/module/config.js
@@ -944,6 +944,17 @@ HERO.areaOfEffect = {
     }
 }
 
+HERO.csl = {
+    options: {
+        SINGLE: "with any single attack",
+        TIGHT: "with a small group of attacks",
+        BROAD: "with a large group of attacks",
+        HTH: "with HTH Combat",
+        RANGED: "with Ranged Combat",
+        ALL: "with All Attacks"
+    }
+}
+
 HERO.stunBodyDamages = {
     "stunbody": "Stun and Body",
     "stunonly": "Stun only",

--- a/module/config.js
+++ b/module/config.js
@@ -877,18 +877,35 @@ HERO.powers5e = {
 
 // For some reason the BASECOST of some modifiers/adder are 0, some are just wrong
 HERO.ModifierOverride = {
-    "DIFFICULTTODISPEL": { BASECOST: 0.25 },
-    "IMPENETRABLE": { BASECOST: 0.25 },
-    "DIMENSIONS": { BASECOST: 5 },
-    "IMPROVEDNONCOMBAT": { BASECOST: 5 },
-    "DEFBONUS": { BASECOST: 2 },
-    "CONTINUOUSCONCENTRATION": { BASECOST: -0.25 },
     "ALWAYSOCCURS": { BASECOST: 0, MULTIPLIER: 2 },
-    "HARDENED": { BASECOST: 0.25 },
-    "PHYSICAL": { BASECOST: 5 }, // DAMAGENEGATION
-    "ENERGY": { BASECOST: 5 }, // DAMAGENEGATION
-    "MENTAL": { BASECOST: 5 }, // DAMAGENEGATION
+    "AOE": { dc: true },
     "ARMORPIERCING": { BASECOST: 0.5 },
+    "ARMORPIERCING": { dc: true },
+    "AUTOFIRE": { dc: true },
+    "AVAD": { dc: true },
+    "BOOSTABLE": { dc: true },
+    "CONTINUOUS": { dc: true },
+    "CONTINUOUSCONCENTRATION": { BASECOST: -0.25 },
+    "DAMAGEOVERTIME": { dc: true },
+    "DEFBONUS": { BASECOST: 2 },
+    "DIFFICULTTODISPEL": { BASECOST: 0.25 },
+    "DIMENSIONS": { BASECOST: 5 },
+    "DOESBODY": { dc: true },
+    "DOUBLEKB": { dc: true },
+    "ENERGY": { BASECOST: 5 }, // DAMAGENEGATION
+    "HARDENED": { BASECOST: 0.25 },
+    "IMPENETRABLE": { BASECOST: 0.25 },
+    "IMPROVEDNONCOMBAT": { BASECOST: 5 },
+    "MENTAL": { BASECOST: 5 }, // DAMAGENEGATION
+    "PENETRATING": { dc: true },
+    "PHYSICAL": { BASECOST: 5 }, // DAMAGENEGATION
+    "STICKY": { dc: true },
+    "TIMELIMIT": { dc: true },
+    "TRANSDIMENSIONAL": { dc: true },
+    "TRIGGER": { dc: true },
+    "UNCONTROLLED": { dc: true },
+    "VARIABLEADVANTAGE": { dc: true },
+    "VARIABLESFX": { dc: true },
 }
 
 // Valid Power Options (found these in Custom Power)

--- a/module/item/item-attack.js
+++ b/module/item/item-attack.js
@@ -5,7 +5,8 @@ import { HEROSYS } from "../herosystem6e.js";
 import { RoundFavorPlayerDown } from "../utility/round.js";
 import {
     determineStrengthDamage, determineExtraDiceDamage,
-    simplifyDamageRoll, convertToDC, handleDamageNegation
+    simplifyDamageRoll, convertToDC, handleDamageNegation,
+    CombatSkillLevelsForAttack
 } from "../utility/damage.js";
 import { damageRollToTag } from "../utility/tag.js";
 import { AdjustmentMultiplier } from "../utility/adjustment.js";
@@ -135,26 +136,12 @@ export async function AttackToHit(item, options) {
     }
 
     // Combat Skill Levels
-    let csl = item.actor.items.find(o=> o.system.XMLID === "COMBAT_LEVELS" && o.system.attacks && o.system.attacks[item.id])
-    if (csl)
-    {
-        let cslOcv = 0
-        for (let i = 0; i < parseInt(csl.system.LEVELS.value); i++)
-        {
-            if (csl.system.csl[i] === 'ocv') cslOcv ++;
-        }
-        if (cslOcv > 0)
-        {
-            rollEquation = modifyRollEquation(rollEquation, cslOcv);
-            tags.push({ value: cslOcv, name: csl.name })
-        }
+    let csl = CombatSkillLevelsForAttack(item);
+    if (csl.ocv > 0) {
+        rollEquation = modifyRollEquation(rollEquation, csl.ocv);
+        tags.push({ value: csl.ocv, name: csl.item.name })
     }
 
-
-    // if (parseInt(options.toHitMod) > 0) {
-    //     rollEquation = modifyRollEquation(rollEquation, options.toHitMod);
-    //     tags.push({ value: options.toHitMod, name: "toHitMod" })
-    // }
 
     // [x Stun, x N Stun, x Body, OCV modifier]
     let noHitLocationsPower = item.system.noHitLocations || false;
@@ -344,6 +331,24 @@ export async function _onRollDamage(event) {
     if (extraDiceDamage !== "") {
         tags.push({ value: extraDiceDamage, name: "extraDice" })
         damageRoll += extraDiceDamage
+    }
+
+    const csl = CombatSkillLevelsForAttack(item)
+    if (csl && csl.dc > 0)
+    {
+
+        let cslDamage = csl.dc + "d6"
+        if (item.system.killing) {
+            cslDamage = Math.floor(csl.dc / 3) + "d6";
+            if (csl.dc % 3 >= 0.5) {
+                cslDamage += " + 1d3"
+            } else if (csl.dc % 3 >= 0.2) {
+                cslDamage += " + 1"
+            }
+        }
+        
+        tags.push({ value: cslDamage, name: csl.item.name })
+        damageRoll += cslDamage
     }
 
     damageRoll = simplifyDamageRoll(damageRoll)

--- a/module/item/item-attack.js
+++ b/module/item/item-attack.js
@@ -134,6 +134,23 @@ export async function AttackToHit(item, options) {
         }
     }
 
+    // Combat Skill Levels
+    let csl = item.actor.items.find(o=> o.system.XMLID === "COMBAT_LEVELS" && o.system.attacks && o.system.attacks[item.id])
+    if (csl)
+    {
+        let cslOcv = 0
+        for (let i = 0; i < parseInt(csl.system.LEVELS.value); i++)
+        {
+            if (csl.system.csl[i] === 'ocv') cslOcv ++;
+        }
+        if (cslOcv > 0)
+        {
+            rollEquation = modifyRollEquation(rollEquation, cslOcv);
+            tags.push({ value: cslOcv, name: csl.name })
+        }
+    }
+
+
     // if (parseInt(options.toHitMod) > 0) {
     //     rollEquation = modifyRollEquation(rollEquation, options.toHitMod);
     //     tags.push({ value: options.toHitMod, name: "toHitMod" })

--- a/module/item/item-sheet.js
+++ b/module/item/item-sheet.js
@@ -111,10 +111,30 @@ export class HeroSystem6eItemSheet extends ItemSheet {
         // Combat Skill Levels
         if (item.system.XMLID === "COMBAT_LEVELS") {
             data.cslChoices = { ocv: "ocv", dcv: "dcv", dc: "dc" }
+
+            // Make sure CSL's are defined
+            if (!item.system.csl) {
+                item.system.csl = {}
+                for (let c = 0; c < parseInt(item.system.LEVELS.value); c++) {
+                    item.system.csl[c] = 'ocv';
+                }
+                item.update({ "system.csl": item.system.csl })
+            }
+
+            // CSL radioBoxes names
             data.csl = []
             for (let c = 0; c < parseInt(item.system.LEVELS.value); c++) {
-                data.csl.push({ name: `csl[${c}]`, value: "ocv" });
+                data.csl.push({ name: `system.csl.${c}`, value: item.system.csl[c] })
             }
+
+            // Enumerate attacks
+            data.attacks = []
+            if (!item.system.attacks)  item.system.attacks = {};
+            for (let attack of item.actor.items.filter(o => o.type == 'attack' || o.system.subType == 'attack')) {
+                if (!item.system.attacks[attack.id]) item.system.attacks[attack.id] = false;
+                data.attacks.push({name: attack.name, id: attack.id, checked: item.system.attacks[attack.id]})
+            }
+
         }
 
 
@@ -124,13 +144,13 @@ export class HeroSystem6eItemSheet extends ItemSheet {
     /* -------------------------------------------- */
 
     /** @override */
-    setPosition(options = {}) {
-        const position = super.setPosition(options)
-        const sheetBody = this.element.find('.sheet-body')
-        const bodyHeight = position.height - 192
-        sheetBody.css('height', bodyHeight)
-        return position
-    }
+    // setPosition(options = {}) {
+    //     const position = super.setPosition(options)
+    //     const sheetBody = this.element.find('.sheet-body')
+    //     const bodyHeight = position.height - 192
+    //     sheetBody.css('height', bodyHeight)
+    //     return position
+    // }
 
     /* -------------------------------------------- */
 

--- a/module/item/item-sheet.js
+++ b/module/item/item-sheet.js
@@ -31,6 +31,10 @@ export class HeroSystem6eItemSheet extends ItemSheet {
         if (["AID", "DRAIN"].includes(this.item.system.XMLID)) {
             return `${path}/item-${this.item.type}-${this.item.system.XMLID.toLowerCase()}-sheet.hbs`
         }
+
+        if (this.item.system.XMLID === "COMBAT_LEVELS") {
+            return `${path}/item-${this.item.type}-combat-levels-sheet.hbs`
+        }
         return `${path}/item-${this.item.type}-sheet.hbs`
     }
 
@@ -103,21 +107,15 @@ export class HeroSystem6eItemSheet extends ItemSheet {
         if (item.system.XMLID == "AID") {
             data.aidSources = AdjustmentSources(this.actor)
         }
-        // if (item.system.XMLID == "AID") {
-        //     let aidSources = []
-        //     for (const key in this.actor.system.characteristics) {
-        //         if (this.actor.system.characteristics[key].hasOwnProperty('value')) {
-        //             aidSources.push(key.toUpperCase())
-        //         }
-        //     }
-        //     aidSources.sort()
-        //     aidSources = ["none", ...aidSources]
-        //     data.aidSources = {}
-        //     for (let key of aidSources) {
-        //         data.aidSources[key] = key
-        //     }
 
-        // }
+        // Combat Skill Levels
+        if (item.system.XMLID === "COMBAT_LEVELS") {
+            data.cslChoices = { ocv: "ocv", dcv: "dcv", dc: "dc" }
+            data.csl = []
+            for (let c = 0; c < parseInt(item.system.LEVELS.value); c++) {
+                data.csl.push({ name: `csl[${c}]`, value: "ocv" });
+            }
+        }
 
 
         return data
@@ -162,7 +160,7 @@ export class HeroSystem6eItemSheet extends ItemSheet {
         html.find('.effect-toggle').click(this._onEffectToggle.bind(this))
 
         // Type
-        html.find('.configure-type').click(this._onConfigureType.bind(this))
+        //html.find('.configure-type').click(this._onConfigureType.bind(this))
 
         // Item Description
         html.find('.textarea').each((id, inp) => {

--- a/module/testing/testing-upload.js
+++ b/module/testing/testing-upload.js
@@ -371,7 +371,7 @@ export function registerUploadTests(quench) {
                 let parser = new DOMParser()
                 let xmlDoc = parser.parseFromString(contents, 'text/xml')
                 let itemData = XmlToItemData.call(actor, xmlDoc.children[0], "martialart")
-                let item = itemData; //await HeroSystem6eItem.create(itemData, { parent: actor, temporary: true })
+                let item = itemData;
                 makeAttack(item);
 
                 it("description", function () {
@@ -433,7 +433,7 @@ export function registerUploadTests(quench) {
                 let parser = new DOMParser()
                 let xmlDoc = parser.parseFromString(contents, 'text/xml')
                 let itemData = XmlToItemData.call(actor, xmlDoc.children[0], "martialart")
-                let item = itemData; //await HeroSystem6eItem.create(itemData, { parent: actor, temporary: true })
+                let item = itemData;
                 makeAttack(item);
 
                 it("description", function () {
@@ -461,7 +461,49 @@ export function registerUploadTests(quench) {
             });
 
 
+            describe("COMBAT_LEVELS", async function () {
+
+                let actor = new HeroSystem6eActor({
+                    name: 'Test Actor',
+                    type: 'pc',
+                }, { temporary: true });
+                actor.system.characteristics.ego.value = 38
+
+                const contents = `
+                <SKILL XMLID="COMBAT_LEVELS" ID="1688944834273" BASECOST="0.0" LEVELS="1" ALIAS="Combat Skill Levels" POSITION="2" MULTIPLIER="1.0" GRAPHIC="Burst" COLOR="255 255 255" SFX="Default" SHOW_ACTIVE_COST="Yes" OPTION="SINGLE" OPTIONID="SINGLE" OPTION_ALIAS="with any single attack" INCLUDE_NOTES_IN_PRINTOUT="Yes" NAME="" CHARACTERISTIC="GENERAL" FAMILIARITY="No" PROFICIENCY="No">
+                <NOTES />
+                </SKILL>
+                    `;
+                let parser = new DOMParser()
+                let xmlDoc = parser.parseFromString(contents, 'text/xml')
+                let itemData = XmlToItemData.call(actor, xmlDoc.children[0], "martialart")
+                let item = itemData; 
+
+                it("description", function () {
+                    assert.equal(item.system.description, "+1 with any single attack");
+                });
+                it("realCost", function () {
+                    assert.equal(item.system.realCost, 2);
+                });
+
+                it("activePoints", function () {
+                    assert.equal(item.system.activePoints, 2);
+                });
+
+                it("end", function () {
+                    assert.equal(item.system.end, "0");
+                });
+            });
+
+
+
+
+
         },
         { displayName: "HERO: Upload" }
     );
+
+
+
+
 }

--- a/module/utility/upload_hdc.js
+++ b/module/utility/upload_hdc.js
@@ -1271,7 +1271,7 @@ function calcActivePoints(_basePointsPlusAdders, system) {
 
     // HALFEND is based on active points without the HALFEND modifier
     if (system.modifiers.find(o => o.XMLID == "REDUCEDEND")) {
-        system._activePointsWithoutEndMods = _basePointsPlusAdders * (1 + advantages -  0.25);
+        system._activePointsWithoutEndMods = _basePointsPlusAdders * (1 + advantages - 0.25);
     }
 
 
@@ -1794,6 +1794,12 @@ export function updateItemDescription(system, type) {
             // (93 Active Points); Limited Range (-1/4), Only In Alternate Identity (-1/4), 
             // Extra Time (Delayed Phase, -1/4), Requires A Roll (14- roll; -1/4)
             system.description = `${system.ALIAS} (${system.LEVELS.value} STR)`
+            break;
+
+        case "MENTAL_COMBAT_LEVELS":
+        case "COMBAT_LEVELS":
+            // +1 with any single attack
+            system.description = `+${system.LEVELS.value} ${system.OPTION_ALIAS}`;
             break;
 
         default:

--- a/module/utility/util.js
+++ b/module/utility/util.js
@@ -34,3 +34,11 @@ export function getPowerInfo(options) {
     }
     return powerInfo
 }
+
+
+
+export function getModifierInfo(options) {
+    const xmlid = options.xmlid || options.item?.system?.XMLID || options.item?.system?.xmlid || options.item?.system?.id
+    const actor = options?.item?.actor || options?.actor
+    return CONFIG.HERO.ModifierOverride[xmlid]
+}

--- a/system.json
+++ b/system.json
@@ -3,7 +3,7 @@
     "name": "hero6e-foundryvtt-v2",
     "title": "Hero System 6e (Unofficial) v2",
     "description": "The Hero System 6e for FoundryVTT!",
-    "version": "3.0.5",
+    "version": "3.0.6",
     "compatibility": {
         "minimum": 11,
         "verified": "11.305",

--- a/templates/actor-sidebar/actor-sidebar-sheet.hbs
+++ b/templates/actor-sidebar/actor-sidebar-sheet.hbs
@@ -290,10 +290,16 @@
             <div class="tab tab-body" data-group="primary" data-tab="skills">
                 <table>
                     <tr class="sticky">
+                        <th colspan="1" class="right">Filter:</th>
+                        <th colspan="4">
+                            <input class="left" name="itemFilters.skill" type="text"
+                                value="{{options.itemFilters.skill}}">
+                        </th>
+                    </tr>
+                    <tr class="sticky2">
                         <th></th>
-                        <th class="left">{{localize "ActorSheet.Name"}}</th>
                         <th>{{localize "ActorSheet.Cost"}}</th>
-                        <th>{{localize "ActorSheet.Characteristic"}}</th>
+                        <th class="left">{{localize "ActorSheet.Name"}}</th>
                         <th>{{localize "ActorSheet.Roll"}}</th>
                         <th>
                             <a class="item-control item-create" title="Create skill" data-type="skill">
@@ -301,18 +307,17 @@
                         </th>
                     </tr>
                     {{#each items as |item id|}}
-                    {{#if (eq item.type "skill") }}
+                    {{#if (and (eq item.type "skill") (filterItem item ../options.itemFilters.skill))}}
                     <tr class="item" data-item-id="{{item._id}}">
                         <td style="min-width: 24px">
                             <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24"
                                     height="24" /></div>
                         </td>
+                        <td>{{item.system.realCost}}</td>
                         <td class="left{{#if item.system.PARENTID}} item-framework-child-name{{/if}}">
                             {{#if item.system.childIdx}}{{item.system.childIdx}}) {{/if}}
                             {{#if item.system.description}}{{item.system.description}}{{else}}{{item.name}}{{/if}}
                         </td>
-                        <td>{{item.system.realCost}}</td>
-                        <td>{{item.system.characteristic}}</td>
                         <td>
                             {{#if item.system.roll}}
                             <button type="button" class="item-rollable" data-roll="{{item.system.roll}}"

--- a/templates/actor-sidebar/actor-sidebar-sheet.hbs
+++ b/templates/actor-sidebar/actor-sidebar-sheet.hbs
@@ -440,7 +440,7 @@
                 <table>
                     <tr class="sticky">
                         <th colspan="2" class="right">Filter:</th>
-                        <th colspan="1">
+                        <th colspan="4">
                             <input class="left" name="itemFilters.power" type="text"
                                 value="{{options.itemFilters.power}}">
                         </th>

--- a/templates/combat/combat-tracker.hbs
+++ b/templates/combat/combat-tracker.hbs
@@ -38,7 +38,7 @@
 
             {{#if combatCount}}
             {{#if combat.round}}
-            <h3 class="encounter-title noborder">{{localize 'COMBAT.Round'}} {{combat.round}}</h3>
+            <h3 class="encounter-title noborder">{{localize 'COMBAT.Turn'}} {{combat.round}}</h3>
             {{else}}
             <h3 class="encounter-title noborder">{{localize 'COMBAT.NotStarted'}}</h3>
             {{/if}}

--- a/templates/item/item-skill-combat-levels-sheet.hbs
+++ b/templates/item/item-skill-combat-levels-sheet.hbs
@@ -1,0 +1,37 @@
+{{ log 'HEROSYS item-skill-combat-levelssheet' this }}
+<form class="{{cssClass}}" autocomplete="off" data-id="{{item._id}}" data-realId="{{item.system.realId}}">
+    <header class="sheet-header">
+        <img class="profile-img" name="img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
+        <div class="header-fields">
+            <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="Name" /></h1>
+        </div>
+    </header>
+
+    {{!-- Sheet Body --}}
+    <section class="sheet-body">
+
+        <div class="form-group">
+            <label>Levels</label>
+            <input type="text" name="system.levels.valuetemplates/item/item-skill-sheet.hbs"
+                value="{{system.levels.value}}" data-dtype="Number" />
+        </div>
+
+
+        {{> systems/hero6efoundryvttv2/templates/item/item-common-partial.hbs item=item }}
+
+
+        <div class="form-group">
+            <label>LEVELS</label>
+            <div class="form-fields">
+                <ol>
+                    {{#each csl}}
+                    <li>
+                        {{ radioBoxes this.name @root/cslChoices checked=this.value localize=true}}
+                    </li>
+                    {{/each}}
+                </ol>
+                
+            </div>
+        </div>
+    </section>
+</form>

--- a/templates/item/item-skill-combat-levels-sheet.hbs
+++ b/templates/item/item-skill-combat-levels-sheet.hbs
@@ -12,12 +12,46 @@
 
         <div class="form-group">
             <label>Levels</label>
-            <input type="text" name="system.levels.valuetemplates/item/item-skill-sheet.hbs"
-                value="{{system.levels.value}}" data-dtype="Number" />
+            <input type="text" name="system.LEVELS.value" value="{{system.LEVELS.value}}" data-dtype="Number" />
+            /
+            <input type="text" name="system.LEVELS.max" value="{{system.LEVELS.max}}" data-dtype="Number" />
+        </div>
+
+        <div class="form-group">
+            <label>OPTIONS</label>
+            <div class="form-fields">
+                <select name="system.OPTION" data-dtype="text">
+                    {{selectOptions config.csl.options selected=system.OPTION}}
+                </select>
+            </div>
         </div>
 
 
-        {{> systems/hero6efoundryvttv2/templates/item/item-common-partial.hbs item=item }}
+        <div class="form-group">
+            <label>OPTION_ALIAS</label>
+            <div class="form-fields">
+                <input name="system.OPTION_ALIAS" type="text" value="{{system.OPTION_ALIAS}}" />
+            </div>
+        </div>
+
+
+        <div class="form-group">
+            <label>Attacks Included:</label>
+            <div class="form-fields csl-attack-list">
+                <ul>
+                    {{#each attacks }}
+                    <li>
+                        <input type="checkbox" name="system.attacks.{{this.id}}" {{checked this.checked}}
+                            data-dtype="Boolean" />
+                        {{this.name}}
+                    </li>
+                    {{/each}}
+                </ul>
+            </div>
+        </div>
+
+
+
 
 
         <div class="form-group">
@@ -30,8 +64,15 @@
                     </li>
                     {{/each}}
                 </ol>
-                
+
             </div>
         </div>
+
+
+
+        {{> systems/hero6efoundryvttv2/templates/item/item-common-partial.hbs item=item }}
+
+
+
     </section>
 </form>


### PR DESCRIPTION
- Fixed issue when deleteting combatant in Combat Traker before combatant begins.
- At Post-Segment-12 all active combatants Take a Recovery.
- Stun status is cleared at the beginning of phase.
- Initial Combat Skill Levels (CSL) support.  OCV is added to attacks.  Simple +1DC. DCV (like all DCV modifiers) is shown but not currently implemented. [#166](https://github.com/dmdorman/hero6e-foundryvtt/issues/166)