### PR TITLE
Version 3.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 - Take a Recovery now also removes the Stunned condition.
 - When characteristics are locked (due to Active Effects) they are now readonly and a tooltip shows what is preventing editing.
 - PD/ED bought as power with resistant modifier and ADD_MODIFIERS_TO_BASE is checked is now supported. [#182](https://github.com/dmdorman/hero6e-foundryvtt/issues/182)
+- Improved Invisibility power description. [#183](https://github.com/dmdorman/hero6e-foundryvtt/issues/183)
+- Fixed Knockback calculations [#188](https://github.com/dmdorman/hero6e-foundryvtt/issues/188)
 
 
 # Version 3.0.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - PD/ED bought as power with resistant modifier and ADD_MODIFIERS_TO_BASE is checked is now supported. [#182](https://github.com/dmdorman/hero6e-foundryvtt/issues/182)
 - Improved Invisibility power description. [#183](https://github.com/dmdorman/hero6e-foundryvtt/issues/183)
 - Fixed Knockback calculations [#188](https://github.com/dmdorman/hero6e-foundryvtt/issues/188)
+- Fixed Martial Killing attack uploads. [#187](https://github.com/dmdorman/hero6e-foundryvtt/issues/187)
+- Damage tags show Damage Classes (DC) [#139](https://github.com/dmdorman/hero6e-foundryvtt/issues/139) [#119](https://github.com/dmdorman/hero6e-foundryvtt/issues/119)
 
 
 # Version 3.0.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 3.0.8
+- Take a Recovery now also removes the Stunned condition.
+- When characteristics are locked (due to Active Effects) they are now readonly and a tooltip shows what is preventing editing.
+- PD/ED bought as power with resistant modifier and ADD_MODIFIERS_TO_BASE is checked is now supported. [#182](https://github.com/dmdorman/hero6e-foundryvtt/issues/182)
+
+
 # Version 3.0.7
 - Initial Mental Combat Skill Levels (MCSL) support. [#166](https://github.com/dmdorman/hero6e-foundryvtt/issues/166)
 - Fixed issue with large worlds failing to load.

--- a/css/actor-sidebar-sheet.css
+++ b/css/actor-sidebar-sheet.css
@@ -320,3 +320,7 @@ input.left {
   margin-left: 2px;
   margin-right: 2px;
 }
+
+ul.left li {
+  text-align: left;
+}

--- a/css/herosystem6e.css
+++ b/css/herosystem6e.css
@@ -660,6 +660,15 @@ form .upload-button {
   list-style-type: none;
 }
 
+div.tags {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.tag {
+  margin-right: 4px;
+}
+
 .tags .tag {
   background-color: #5e0000;
   border-radius: 2px;

--- a/module/actor/actor-active-effects.js
+++ b/module/actor/actor-active-effects.js
@@ -26,7 +26,7 @@ export class HeroSystem6eActorActiveEffects extends ActiveEffect {
 
     // A Stunned character’s DCV and DMCV are instantly halved.
     static stunEffect = {
-        label: "EFFECT.StatusStunned",
+        name: "EFFECT.StatusStunned",
         id: "stunned",
         icon: 'icons/svg/daze.svg',
         changes: [
@@ -36,13 +36,13 @@ export class HeroSystem6eActorActiveEffects extends ActiveEffect {
     };
 
     static bleedingEffect = {
-        label: "EFFECT.StatusBleeding",
+        name: "EFFECT.StatusBleeding",
         id: "bleeding",
         icon: 'icons/svg/blood.svg',
     };
 
     static unconsciousEffect = {
-        label: "EFFECT.StatusUnconscious",
+        name: "EFFECT.StatusUnconscious",
         id: "unconscious",
         icon: 'icons/svg/unconscious.svg',
         changes: [
@@ -52,7 +52,7 @@ export class HeroSystem6eActorActiveEffects extends ActiveEffect {
     };
 
     static knockedOutEffect = {
-        label: "EFFECT.StatusKnockedOut",
+        name: "EFFECT.StatusKnockedOut",
         id: "knockedOut",
         icon: 'icons/svg/stoned.svg',
         changes: [
@@ -64,7 +64,7 @@ export class HeroSystem6eActorActiveEffects extends ActiveEffect {
     };
 
     static deadEffect = {
-        label: "EFFECT.StatusDead",
+        name: "EFFECT.StatusDead",
         id: "dead",
         icon: 'icons/svg/skull.svg',
         changes: [
@@ -84,7 +84,7 @@ export class HeroSystem6eActorActiveEffects extends ActiveEffect {
     // Ranged Combat, and -1 DCV in HTH Combat (full DCV at Range).
     // These effects last until the beginning of the character’s next Phase.
     static blindEffect = {
-        label: "EFFECT.StatusBlind",
+        name: "EFFECT.StatusBlind",
         id: "blind",
         icon: 'icons/svg/blind.svg',
         // changes: [
@@ -94,7 +94,7 @@ export class HeroSystem6eActorActiveEffects extends ActiveEffect {
     };
 
     static asleepEffect = {
-        label: "EFFECT.StatusAsleep",
+        name: "EFFECT.StatusAsleep",
         id: "asleep",
         icon: 'icons/svg/sleep.svg',
         // changes: [

--- a/module/actor/actor-sidebar-sheet.js
+++ b/module/actor/actor-sidebar-sheet.js
@@ -415,6 +415,32 @@ export class HeroSystem6eActorSidebarSheet extends ActorSheet {
                 }
             }
 
+            // Active Effects may be blocking updates
+            let ary = []
+            let activeEffects = Array.from(this.actor.allApplicableEffects()).filter(o=> o.changes.find(p=> p.key === `system.characteristics.${key}.value`));
+            for (let ae of activeEffects) {
+                ary.push(`<li>${ae.name}</li>`);
+            }
+            if (ary.length > 0)
+            {
+                characteristic.valueTitle = "<b>PREVENTING CHANGES</b>\n<ul class='left'>";
+                characteristic.valueTitle += ary.join('\n ');
+                characteristic.valueTitle += "</ul>";
+            }
+
+            ary = []
+            activeEffects = Array.from(this.actor.allApplicableEffects()).filter(o=> o.changes.find(p=> p.key === `system.characteristics.${key}.max`));
+            for (let ae of activeEffects) {
+                ary.push(`<li>${ae.name}</li>`);
+            }
+            if (ary.length > 0)
+            {
+                characteristic.maxTitle = "<b>PREVENTING CHANGES</b>\n<ul class='left'>";
+                characteristic.maxTitle += ary.join('\n ');
+                characteristic.maxTitle += "</ul>";
+            }
+            
+
             characteristicSet.push(characteristic)
         }
         data.characteristicSet = characteristicSet

--- a/module/actor/actor-sidebar-sheet.js
+++ b/module/actor/actor-sidebar-sheet.js
@@ -105,7 +105,8 @@ export class HeroSystem6eActorSidebarSheet extends ActorSheet {
                 // Combat Skill Levels
                 const csl = CombatSkillLevelsForAttack(item)
 
-                let dc = convertToDcFromItem(item);
+                let {dc, end} = convertToDcFromItem(item);
+                item.system.endEstimate += end;
 
                 // // Convert dice to pips
                 // let pips = item.system.dice * 3;
@@ -162,7 +163,7 @@ export class HeroSystem6eActorSidebarSheet extends ActorSheet {
                 // let extraDice = pips - fullDice * 3
 
                 // text descrdiption of damage
-                item.system.damage = convertFromDC(item, dc)  /*fullDice
+                item.system.damage = convertFromDC(item, dc).replace(/ /g, "");  /*fullDice
                 switch (extraDice) {
                     case 0:
                         item.system.damage += 'D6'

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -262,6 +262,11 @@ export class HeroSystem6eActor extends Actor {
 
         if (asAction) {
             await ChatMessage.create(chatData)
+
+            // Remove stunned condition.
+            // While not technically part of the rules, it is here as a convenience.
+            // For example when Combat Tracker isn't being used.
+            await this.removeActiveEffect(HeroSystem6eActorActiveEffects.stunEffect);
         }
 
         return content;

--- a/module/card/card.js
+++ b/module/card/card.js
@@ -116,7 +116,7 @@ export class HeroSystem6eCard {
         // Add a new effect
         else {
             const createData = foundry.utils.deepClone(effectData);
-            createData.label = game.i18n.localize(effectData.label);
+            createData.name = game.i18n.localize(effectData.name);
             createData["flags.core.statusId"] = effectData.id;
             delete createData.id;
             const cls = getDocumentClass("ActiveEffect");
@@ -152,7 +152,7 @@ export class HeroSystem6eCard {
         const existing = target.effects.find(e => e.getFlag("core", "statusId") === effectData.id);
         if (!existing) {
             const createData = foundry.utils.deepClone(effectData);
-            createData.label = game.i18n.localize(effectData.label);
+            createData.name = game.i18n.localize(effectData.name || effectData.label);
             createData["flags.core.statusId"] = effectData.id;
             delete createData.id;
             const cls = getDocumentClass("ActiveEffect");

--- a/module/config.js
+++ b/module/config.js
@@ -616,7 +616,15 @@ HERO.powers = {
         costEnd: true,
         costPerLevel: 1,
     },
-
+    "INVISIBILITY": { 
+        name: "Invisibility",
+        powerType: ["sense-affecting"],
+        percievability: "Special",
+        duration: "Constant",
+        target: "Self Only",
+        range: "Self",
+        costEnd: true,
+    },
 
     // Defense
     "FORCEWALL": {

--- a/module/item/item-attack.js
+++ b/module/item/item-attack.js
@@ -688,15 +688,15 @@ async function _onApplyAdjustmentToSpecificToken(event, tokenId) {
 
             prevEffect.changes[0].value = newLevels
 
-            prevEffect.name = `${item.system.XMLID} ${newLevels} ${key.toUpperCase()} from ${item.actor.name}`,
+            prevEffect.name = `${item.system.XMLID} ${newLevels} ${key.toUpperCase()} from ${item.actor.name}`;
 
-                prevEffect.update({ name: prevEffect.name, changes: prevEffect.changes })
+            prevEffect.update({ name: prevEffect.name, changes: prevEffect.changes })
 
         } else {
             // Create new ActiveEffect
             let activeEffect =
             {
-                name: `${item.system.XMLID} ${levels} ${key.toUpperCase()} from ${item.actor.name}`,
+                label: `${item.system.XMLID} ${levels} ${key.toUpperCase()} from ${item.actor.name}`,
                 icon: item.img,
                 changes: [
                     {

--- a/module/item/item.js
+++ b/module/item/item.js
@@ -5,7 +5,7 @@ import * as Dice from "../dice.js"
 import * as Attack from "../item/item-attack.js"
 import { createSkillPopOutFromItem } from '../item/skill.js'
 import { enforceManeuverLimits } from '../item/manuever.js'
-import { SkillRollUpdateValue, updateItem } from '../utility/upload_hdc.js'
+import { SkillRollUpdateValue, updateItem, updateItemDescription } from '../utility/upload_hdc.js'
 import { onActiveEffectToggle } from '../utility/effects.js'
 import { getPowerInfo } from '../utility/util.js'
 
@@ -154,6 +154,8 @@ export class HeroSystem6eItem extends Item {
     }
 
     async chat() {
+
+        updateItemDescription(this);
 
         let content = `<div class="item-chat">`
 

--- a/module/testing/testing-upload.js
+++ b/module/testing/testing-upload.js
@@ -223,10 +223,10 @@ export function registerUploadTests(quench) {
                 itemData.actor = actor
                 let item = itemData; // await HeroSystem6eItem.create(itemData, { parent: actor, temporary: true })
                 makeAttack(item);
-                updateItemDescription.call(item, item.system, item.type)
+                updateItemDescription(item)
 
                 it("description", function () {
-                    assert.equal(item.system.description, "Offensive Strike: 1/2 Phase, -2 OCV, +1 DCV, 6d6 Strike");
+                    assert.equal(item.system.description, "1/2 Phase, -2 OCV, +1 DCV, 6d6 Strike");
                 });
                 it("realCost", function () {
                     assert.equal(item.system.realCost, 5);
@@ -545,6 +545,43 @@ export function registerUploadTests(quench) {
                 });
             });
 
+
+            describe("Killing Strike", async function () {
+
+                let actor = new HeroSystem6eActor({
+                    name: 'Test Actor',
+                    type: 'pc',
+                }, { temporary: true });
+                actor.system.characteristics.ego.value = 38
+
+                const contents = `
+                <MANEUVER XMLID="MANEUVER" ID="1689357675658" BASECOST="4.0" LEVELS="0" ALIAS="Killing Strike" POSITION="2" MULTIPLIER="1.0" GRAPHIC="Burst" COLOR="255 255 255" SFX="Default" SHOW_ACTIVE_COST="Yes" INCLUDE_NOTES_IN_PRINTOUT="Yes" NAME="" CATEGORY="Hand To Hand" DISPLAY="Killing Strike" OCV="-2" DCV="+0" DC="2" PHASE="1/2" EFFECT="[KILLINGDC]" ADDSTR="Yes" ACTIVECOST="10" DAMAGETYPE="0" MAXSTR="10" STRMULT="1" USEWEAPON="No" WEAPONEFFECT="[WEAPONKILLINGDC]">
+                <NOTES />
+                </MANEUVER>
+                    `;
+                let parser = new DOMParser()
+                let xmlDoc = parser.parseFromString(contents, 'text/xml')
+                let itemData = XmlToItemData.call(actor, xmlDoc.children[0], "power")
+                itemData.actor = actor
+                let item = itemData;
+                makeAttack(item);
+                updateItemDescription(item);
+
+                it("description", function () {
+                    assert.equal(item.system.description, "1/2 Phase, -2 OCV, +0 DCV, HKA 1d6 +1");
+                });
+                it("realCost", function () {
+                    assert.equal(item.system.realCost, 4);
+                });
+
+                it("activePoints", function () {
+                    assert.equal(item.system.activePoints, 4);
+                });
+
+                it("end", function () {
+                    assert.equal(item.system.end, "0");
+                });
+            });
 
 
 

--- a/module/testing/testing-upload.js
+++ b/module/testing/testing-upload.js
@@ -496,6 +496,57 @@ export function registerUploadTests(quench) {
             });
 
 
+            describe("INVISIBILITY", async function () {
+
+                let actor = new HeroSystem6eActor({
+                    name: 'Test Actor',
+                    type: 'pc',
+                }, { temporary: true });
+                actor.system.characteristics.ego.value = 38
+
+                const contents = `
+                <POWER XMLID="INVISIBILITY" ID="1689283663052" BASECOST="20.0" LEVELS="0" ALIAS="Invisibility" POSITION="1" MULTIPLIER="1.0" GRAPHIC="Burst" COLOR="255 255 255" SFX="Default" SHOW_ACTIVE_COST="Yes" OPTION="SIGHTGROUP" OPTIONID="SIGHTGROUP" OPTION_ALIAS="Sight Group" INCLUDE_NOTES_IN_PRINTOUT="Yes" NAME="Blind Minds" QUANTITY="1" AFFECTS_PRIMARY="No" AFFECTS_TOTAL="Yes">
+                <NOTES />
+                <ADDER XMLID="TOUCHGROUP" ID="1689356871509" BASECOST="5.0" LEVELS="0" ALIAS="Touch Group" POSITION="-1" MULTIPLIER="1.0" GRAPHIC="Burst" COLOR="255 255 255" SFX="Default" SHOW_ACTIVE_COST="Yes" INCLUDE_NOTES_IN_PRINTOUT="Yes" NAME="" SHOWALIAS="Yes" PRIVATE="No" REQUIRED="No" INCLUDEINBASE="Yes" DISPLAYINSTRING="No" GROUP="No" LVLCOST="-1.0" LVLVAL="-1.0" SELECTED="YES">
+                  <NOTES />
+                </ADDER>
+                <ADDER XMLID="NORMALSMELL" ID="1689356871510" BASECOST="3.0" LEVELS="0" ALIAS="Normal Smell" POSITION="-1" MULTIPLIER="1.0" GRAPHIC="Burst" COLOR="255 255 255" SFX="Default" SHOW_ACTIVE_COST="Yes" INCLUDE_NOTES_IN_PRINTOUT="Yes" NAME="" SHOWALIAS="Yes" PRIVATE="No" REQUIRED="No" INCLUDEINBASE="Yes" DISPLAYINSTRING="No" GROUP="No" LVLCOST="-1.0" LVLVAL="-1.0" SELECTED="YES">
+                  <NOTES />
+                </ADDER>
+                <ADDER XMLID="COMBAT_SENSE" ID="1689356871511" BASECOST="5.0" LEVELS="0" ALIAS="Combat Sense" POSITION="-1" MULTIPLIER="1.0" GRAPHIC="Burst" COLOR="255 255 255" SFX="Default" SHOW_ACTIVE_COST="Yes" INCLUDE_NOTES_IN_PRINTOUT="Yes" NAME="" SHOWALIAS="Yes" PRIVATE="No" REQUIRED="No" INCLUDEINBASE="Yes" DISPLAYINSTRING="No" GROUP="No" LVLCOST="-1.0" LVLVAL="-1.0" SELECTED="YES">
+                  <NOTES />
+                </ADDER>
+                <ADDER XMLID="HEARINGGROUP" ID="1689356871512" BASECOST="5.0" LEVELS="0" ALIAS="Hearing Group" POSITION="-1" MULTIPLIER="1.0" GRAPHIC="Burst" COLOR="255 255 255" SFX="Default" SHOW_ACTIVE_COST="Yes" INCLUDE_NOTES_IN_PRINTOUT="Yes" NAME="" SHOWALIAS="Yes" PRIVATE="No" REQUIRED="No" INCLUDEINBASE="Yes" DISPLAYINSTRING="No" GROUP="No" LVLCOST="-1.0" LVLVAL="-1.0" SELECTED="YES">
+                  <NOTES />
+                </ADDER>
+                <MODIFIER XMLID="CONDITIONALPOWER" ID="1689356871533" BASECOST="-0.5" LEVELS="0" ALIAS="Conditional Power" POSITION="-1" MULTIPLIER="1.0" GRAPHIC="Burst" COLOR="255 255 255" SFX="Default" SHOW_ACTIVE_COST="Yes" OPTION="COMMON" OPTIONID="COMMON" OPTION_ALIAS="Only vs organic perception" INCLUDE_NOTES_IN_PRINTOUT="Yes" NAME="" COMMENTS="" PRIVATE="No" FORCEALLOW="No">
+                  <NOTES />
+                </MODIFIER>
+              </POWER>
+                    `;
+                let parser = new DOMParser()
+                let xmlDoc = parser.parseFromString(contents, 'text/xml')
+                let itemData = XmlToItemData.call(actor, xmlDoc.children[0], "power")
+                let item = itemData; 
+
+                it("description", function () {
+                    assert.equal(item.system.description, "Invisibility to Sight, Touch and Hearing Groups, Normal Smell and Combat Sense (38 Active Points); Conditional Power Only vs organic perception (-1/2)");
+                });
+                it("realCost", function () {
+                    assert.equal(item.system.realCost, 25);
+                });
+
+                it("activePoints", function () {
+                    assert.equal(item.system.activePoints, 38);
+                });
+
+                it("end", function () {
+                    assert.equal(item.system.end, "4");
+                });
+            });
+
+
+
 
 
 

--- a/module/utility/defense.js
+++ b/module/utility/defense.js
@@ -51,6 +51,12 @@ function determineDefense(targetActor, attackItem) {
             PD -= levels
             rPD += levels
         }
+
+        if (item.system.ADD_MODIFIERS_TO_BASE === "Yes")
+        {
+            PD -= targetActor.system.characteristics.pd.core;
+            rPD += targetActor.system.characteristics.pd.core;
+        }
     }
 
     // ED bought as resistant
@@ -60,6 +66,12 @@ function determineDefense(targetActor, attackItem) {
             const levels = parseInt(item.system.LEVELS.value) || 0
             ED -= levels
             rED += levels
+        }
+
+        if (item.system.ADD_MODIFIERS_TO_BASE === "Yes")
+        {
+            ED -= targetActor.system.characteristics.ed.core;
+            rED += targetActor.system.characteristics.ed.core;
         }
     }
 

--- a/module/utility/upload_hdc.js
+++ b/module/utility/upload_hdc.js
@@ -553,7 +553,7 @@ export function XmlToItemData(xml, type) {
         'PRIVATE', 'EVERYMAN', 'CHARACTERISTIC', 'NATIVE_TONGUE', 'POWDLEVELS',
         "WEIGHT", "PRICE", "CARRIED", "LENGTHLEVELS", "HEIGHTLEVELS", "WIDTHLEVELS",
         "BODYLEVELS", "ID", "PARENTID", "POSITION", "AFFECTS_TOTAL",
-        "CATEGORY", "PHASE", "OCV", "DCV", "DC", "EFFECT"
+        "CATEGORY", "PHASE", "OCV", "DCV", "DC", "EFFECT", "ADD_MODIFIERS_TO_BASE"
     ]
     for (const attribute of xml.attributes) {
         if (relevantFields.includes(attribute.name)) {

--- a/system.json
+++ b/system.json
@@ -3,7 +3,7 @@
     "name": "hero6e-foundryvtt-v2",
     "title": "Hero System 6e (Unofficial) v2",
     "description": "The Hero System 6e for FoundryVTT!",
-    "version": "3.0.7",
+    "version": "3.0.8",
     "compatibility": {
         "minimum": 11,
         "verified": "11.305",

--- a/templates/actor-sidebar/actor-sidebar-sheet.hbs
+++ b/templates/actor-sidebar/actor-sidebar-sheet.hbs
@@ -566,14 +566,15 @@
                     </tr>
                     {{#each characteristicSet as |characteristic key|}}
                     <tr class="characteristic">
-                        <td>
+                        <td data-tooltip="{{{characteristic.valueTitle}}}">
                             <input name="system.characteristics.{{characteristic.key}}.value" type="text"
                                 value="{{characteristic.value}}" data-dtype="Number"
-                                class="{{#if (gt characteristic.value characteristic.max)}}overMax{{/if}}{{#if (lt characteristic.value characteristic.max)}}underMax{{/if}}">
+                                class="{{#if (gt characteristic.value characteristic.max)}}overMax{{/if}}{{#if (lt characteristic.value characteristic.max)}}underMax{{/if}}"
+                                 {{#if characteristic.valueTitle}}disabled{{/if}}>
                         </td>
-                        <td>
+                        <td data-tooltip="{{{characteristic.maxTitle}}}">
                             <input name="system.characteristics.{{characteristic.key}}.max" type="text"
-                                value="{{characteristic.max}}" data-dtype="Number">
+                                value="{{characteristic.max}}" data-dtype="Number" {{#if characteristic.maxTitle}}disabled{{/if}}>
                         </td>
                         <td>
                             {{characteristic.core}}

--- a/templates/chat/item-toHit-card.hbs
+++ b/templates/chat/item-toHit-card.hbs
@@ -47,7 +47,7 @@
             <span class="tag">killing</span>
             {{/if}}
             {{#if (ne item.system.stunBodyDamage 'stunbody')}}
-            <span class="tag">{{item.system.stunBodyDamage}}</span>
+            <span class="tag">{{item.system.stunBodyDamage}}S</span>
             {{/if}}
             {{#if item.system.piercing}}
             <span class="tag" title="Armor Piercing">APx{{item.system.piercing}}</span>


### PR DESCRIPTION
# Version 3.0.8
- Take a Recovery now also removes the Stunned condition.
- When characteristics are locked (due to Active Effects) they are now readonly and a tooltip shows what is preventing editing.
- PD/ED bought as power with resistant modifier and ADD_MODIFIERS_TO_BASE is checked is now supported. [#182](https://github.com/dmdorman/hero6e-foundryvtt/issues/182)
- Improved Invisibility power description. [#183](https://github.com/dmdorman/hero6e-foundryvtt/issues/183)
- Fixed Knockback calculations [#188](https://github.com/dmdorman/hero6e-foundryvtt/issues/188)
- Fixed Martial Killing attack uploads. [#187](https://github.com/dmdorman/hero6e-foundryvtt/issues/187)
- Damage tags show Damage Classes (DC) [#139](https://github.com/dmdorman/hero6e-foundryvtt/issues/139) [#119](https://github.com/dmdorman/hero6e-foundryvtt/issues/119)
