### PR TITLE
Correct actor images for multiple uploads

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -1065,6 +1065,9 @@ export class HeroSystem6eActor extends Actor {
             }
 
             delete heroJson.CHARACTER.IMAGE
+        } else {
+            // No image provided. Make sure we're using the default token.
+            changes['img'] = CONST.DEFAULT_TOKEN
         }
 
 

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -1030,38 +1030,40 @@ export class HeroSystem6eActor extends Actor {
             }
         }
 
-        // Actor Image
+        // Images
         if (heroJson.CHARACTER.IMAGE) {
             const filename = heroJson.CHARACTER.IMAGE?.FileName
-            try {
-                const extension = filename.split('.').pop()
-                const base64 = "data:image/" + extension + ";base64," + xml.getElementsByTagName('IMAGE')[0].textContent
                 const path = "worlds/" + game.world.id + "/tokens"
+            const relativePathName = path + "/" + filename
+
+            // Create a directory if it doesn't already exist
                 try {
                     await FilePicker.createDirectory("user", path)
                 } catch (e) {
-                    //console.log(e)
+                //console.error(e)
                 }
-                let oldImage = null
-                try {
-                    //let files = (await FilePicker.browse("user", path)).files
-                    oldImage = (await FilePicker.browse("user", path)).files.includes(encodeURI(path + "/" + filename))
-                } catch (e) {
-                    //console.log(e)
-                }
-                if (!oldImage) { //this.img.indexOf(filename) == -1) {
+
+            // Set the image, uploading if not already in the file system
+            try {
+                const imageFileExists = (await FilePicker.browse("user", path)).files.includes(encodeURI(relativePathName))
+                if (!imageFileExists) {
+                    const extension = filename.split('.').pop()
+                    const base64 = "data:image/" + extension + ";base64," + xml.getElementsByTagName('IMAGE')[0].textContent
+
                     await ImageHelper.uploadBase64(base64, filename, path)
-                    changes['img'] = path + '/' + filename
 
                     // Update any tokens images that might exist
                     for (const token of this.getActiveTokens()) {
-                        await token.document.update({ 'texture.src': path + '/' + filename })
+                        await token.document.update({ 'texture.src': relativePathName })
                     }
                 }
+
+                changes['img'] = relativePathName
             } catch (e) {
-                console.log(e)
-                ui.notifications.warn(`${this.name} failed to upload ${filename}.`);
+                console.error(e)
+                ui.notifications.warn(`${this.name} failed to upload ${filename}.`)
             }
+
             delete heroJson.CHARACTER.IMAGE
         }
 
@@ -1083,7 +1085,7 @@ export class HeroSystem6eActor extends Actor {
         }
 
 
-        // Save all our changes (unless tempoary actor/quench)
+        // Save all our changes (unless temporary actor/quench)
         if (this.id) {
             await this.update(changes)
         }

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -1033,15 +1033,15 @@ export class HeroSystem6eActor extends Actor {
         // Images
         if (heroJson.CHARACTER.IMAGE) {
             const filename = heroJson.CHARACTER.IMAGE?.FileName
-                const path = "worlds/" + game.world.id + "/tokens"
+            const path = "worlds/" + game.world.id + "/tokens"
             const relativePathName = path + "/" + filename
 
             // Create a directory if it doesn't already exist
-                try {
-                    await FilePicker.createDirectory("user", path)
-                } catch (e) {
+            try {
+                await FilePicker.createDirectory("user", path)
+            } catch (e) {
                 //console.error(e)
-                }
+            }
 
             // Set the image, uploading if not already in the file system
             try {
@@ -1208,11 +1208,10 @@ export class HeroSystem6eActor extends Actor {
             await this.update({ [`system.is5e`]: this.system.is5e })
         }
 
-        // Chararacteristics
+        // Characteristics
         for (const key of Object.keys(this.system.characteristics)) {
             if (key === "running")
                 console.log(key)
-            const powerInfo = getPowerInfo({ xmlid: key.toUpperCase(), actor: this });
             let newValue = parseInt(this.system?.[key.toUpperCase()]?.LEVELS || 0)
             newValue += this.getCharacteristicBase(key)
             if (this.system.characteristics[key].max != newValue) {


### PR DESCRIPTION
* New uploads would work, but uploading an existing token or sharing tokens would not.
* Now restores the default image if uploading an HDC without an image into an actor with an image
* Also cleaned up the image upload a bit.
* Two spelling corrections