### PR TITLE
Add format and static analysis validation stage for PRs and Releases

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -1,0 +1,19 @@
+name: Check PRs conform to code format and lint standards
+
+on: pull_request
+
+jobs:
+    validate:
+        runs-on: ubuntu-latest
+
+        steps:
+        - uses: actions/checkout@v2
+
+        - name: Install
+          run: npm ci
+  
+        - name: Is it pretty?
+          run: npm run prettier
+
+        - name: Any eslint issues?
+          run: npm run prettier

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         if [[ "${{ steps.extract_version.outputs.VERSION }}" != "${{ steps.latest_release.outputs.LATEST_RELEASE }}" ]]; then
           RELEASE="${{ steps.extract_version.outputs.VERSION }}"
           echo "::set-output name=RELEASE::$RELEASE"
-        fi  
+        fi
 
   prepare_release:
     needs: check_release
@@ -50,6 +50,9 @@ jobs:
 
     - name: build css
       run: npm ci && npm run compile
+
+    - name: validate formatting (via prettier) and perform static analysis (via eslint)
+      run: npm run validate
 
     - name: Update release version in system.json
       run: |


### PR DESCRIPTION
Add a new `pull_request` workflow that that will verify that `prettier` and `eslint` pass for the proposed PR. This means that JavaScript source code conforms to the standard and that JavaScript code passes what limited static analysis eslint can do. This will result in an `All checks have passed` notice along with the usual `This branch has no conflicts with the base branch` for PRs that are conforming.

![image](https://github.com/dmdorman/hero6e-foundryvtt/assets/29824554/a60582b9-a392-4253-9944-1a901e3f01f0)

Full details of each step should be available by following the "Show all checks" link.

Additionally the `prepare_release` job now requires that `npm run validate` succeed to produce a release.