### PR TITLE
Release 3.0.53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Releases
 
-## Version 3.0.53 (so far...)
+## Version 3.0.53
 
 - Fix crash with Aid and Telekinesis powers during upload. [#474](https://github.com/dmdorman/hero6e-foundryvtt/issues/474)
 - Correct general skill roll calculations to be 11 plus levels. [#456](https://github.com/dmdorman/hero6e-foundryvtt/issues/456)
@@ -10,7 +10,7 @@
 - Fix missing display of BACKGROUND an other character information. [#483](https://github.com/dmdorman/hero6e-foundryvtt/issues/483)
 - Configuration setting to toggle custom resource bars.  Existing worlds will retain custom resource bars, new worlds will default to core FoundryVTT resource bars.  The [Bar Brawl](https://foundryvtt.com/packages/barbrawl) module is superior, although requires some configuration.  Bugs related to system custom bars still exist.  We are likely to deprecate the custom resource bars in this system. [#502](https://github.com/dmdorman/hero6e-foundryvtt/issues/502) [#368](https://github.com/dmdorman/hero6e-foundryvtt/issues/368) [#274](https://github.com/dmdorman/hero6e-foundryvtt/issues/274) [#174](https://github.com/dmdorman/hero6e-foundryvtt/issues/174)
 - Skill characteristics can now be changed in game and will update appropriately. [#511](https://github.com/dmdorman/hero6e-foundryvtt/issues/511)
-- Power descriptions should now have the power names in them. While descriptions are still not perfect they should be better. Let us know if anything particularly terrible remains.
+- Power, skill, etc descriptions should now have the user given names in them. While descriptions are still not perfect they should be better. Let us know if anything particularly terrible remains.
 - Lots of behind the scenes work to help improve readability and consistency of the code.
 
 ## Version 3.0.52

--- a/system.json
+++ b/system.json
@@ -3,7 +3,7 @@
     "name": "hero6e-foundryvtt-v2",
     "title": "Hero System 6e (Unofficial) v2",
     "description": "The Hero System 6e for FoundryVTT!",
-    "version": "3.0.52",
+    "version": "3.0.53",
     "compatibility": {
         "minimum": 11,
         "verified": "11.315",


### PR DESCRIPTION
## Version 3.0.53

- Fix crash with Aid and Telekinesis powers during upload. [#474](https://github.com/dmdorman/hero6e-foundryvtt/issues/474)
- Correct general skill roll calculations to be 11 plus levels. [#456](https://github.com/dmdorman/hero6e-foundryvtt/issues/456)
- Improvements to a number of 5e power cost calculations (MP, EC, Forcefield, Teleport, Stretching, Multiform, Aid, Suppress) and INCREASEDMAX adder during upload.
- Characters with incompletely defined adjustment powers will get a warning during upload with a hint on how to fix them.
- Fix HDC uploads when name is missing from HDC file.
- Fix missing display of BACKGROUND an other character information. [#483](https://github.com/dmdorman/hero6e-foundryvtt/issues/483)
- Configuration setting to toggle custom resource bars.  Existing worlds will retain custom resource bars, new worlds will default to core FoundryVTT resource bars.  The [Bar Brawl](https://foundryvtt.com/packages/barbrawl) module is superior, although requires some configuration.  Bugs related to system custom bars still exist.  We are likely to deprecate the custom resource bars in this system. [#502](https://github.com/dmdorman/hero6e-foundryvtt/issues/502) [#368](https://github.com/dmdorman/hero6e-foundryvtt/issues/368) [#274](https://github.com/dmdorman/hero6e-foundryvtt/issues/274) [#174](https://github.com/dmdorman/hero6e-foundryvtt/issues/174)
- Skill characteristics can now be changed in game and will update appropriately. [#511](https://github.com/dmdorman/hero6e-foundryvtt/issues/511)
- Power, skill, etc descriptions should now have the user given names in them. While descriptions are still not perfect they should be better. Let us know if anything particularly terrible remains.
- Lots of behind the scenes work to help improve readability and consistency of the code.
