### PR TITLE
GitHub Workflow Improvements

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v4
 
         - name: Install
           run: npm ci

--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -16,4 +16,4 @@ jobs:
           run: npm run prettier
 
         - name: Any eslint issues?
-          run: npm run prettier
+          run: npm run lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       release: ${{ steps.extract_release.outputs.RELEASE }}
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Install jq
       run: sudo apt-get install jq
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: build css
       run: npm ci && npm run compile
@@ -64,10 +64,11 @@ jobs:
         zip -r hero6efoundryvttv2.zip .
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: hero6efoundryvttv2.zip
         path: hero6efoundryvttv2.zip
+        if-no-files-found: error
 
     - name: Create and push tag
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,7 @@ jobs:
       run: wget https://github.com/${{ github.repository }}/releases/download/${{ needs.prepare_release.outputs.release_name }}/system.json
 
     - name: Publish to Foundry
-      uses: Varriount/fvtt-autopublish@v1.1.1
+      uses: Varriount/fvtt-autopublish@v2.0.1
       with:
         username: ${{ secrets.FOUNDRY_ADMIN_USERNAME }}
         password: ${{ secrets.FOUNDRY_ADMIN_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,9 +59,9 @@ jobs:
         sed -i 's|"manifest": "[^"]*",|"manifest": "https://github.com/dmdorman/hero6e-foundryvtt/releases/download/${{ needs.check_release.outputs.release }}/system.json",|' system.json
         sed -i 's|"download": "[^"]*",|"download": "https://github.com/dmdorman/hero6e-foundryvtt/releases/download/${{ needs.check_release.outputs.release }}/hero6efoundryvttv2.zip",|' system.json
 
-    - name: Archive code
+    - name: Make a FoundryVTT system package (manifest and stuff required for execution) and ignore the rest as it is already archived in GitHub and is only needed to build or develop
       run: |
-        zip -r hero6efoundryvttv2.zip .
+        zip -r herofoundryvttv2.zip . -x .git/\* -x .github/\* -x node_modules/\* -x scss/\* -x .gitattributes -x .gitignore  -x .git-blame-ignore-revs -x .eslintrc.json -x .npmignore -x .prettierignore -x .prettierrc.json -x gulpfile.mjs -x package.json -x package-lock.json
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,6 @@
 
 # Ignore all json files
 **/*.json
+
+# Ignore all yaml files
+**/*.yml

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -5,7 +5,6 @@ import {
     getPowerInfo,
     getCharacteristicInfoArrayForActor,
 } from "../utility/util.js";
-import { AdjustmentSources } from "../utility/adjustment.js";
 
 /**
  * Extend the base Actor entity by defining a custom roll data structure which is ideal for the Simple system.


### PR DESCRIPTION
- Run GitHub actions on node 20
- Fix PR checker so that it actually checks lint
- Update `fvtt-autopublish` package.
- Shrink package size from 38MB to 4MB by not including build and development related content.