### PR TITLE
Bug fixes

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -780,7 +780,7 @@ export class HeroSystem6eActor extends Actor {
 
         // Remove temporary effects
         const tempEffects = Array.from(this.effects).filter(
-            (o) => parseInt(o.duration?.seconds || 0) > 0,
+            (effect) => parseInt(effect.duration?.seconds || 0) > 0,
         );
         for (const ae of tempEffects) {
             await ae.delete();

--- a/module/item/item.js
+++ b/module/item/item.js
@@ -119,11 +119,15 @@ export class HeroSystem6eItem extends Item {
         }
 
         // Remove temporary effects
-        const effectPromises = Promise.all(
-            this.effects.map(async (effect) => await effect.delete()),
+        const temporaryEffectPromises = Promise.all(
+            this.effects.map(async (effect) => {
+                if (parseInt(effect.duration?.seconds || 0) > 0) {
+                    await effect.delete();
+                }
+            }),
         );
 
-        await effectPromises;
+        await temporaryEffectPromises;
 
         if (this.system.value !== this.system.max) {
             await this.update({ ["system.value"]: this.system.max });

--- a/module/testing/testing-upload.js
+++ b/module/testing/testing-upload.js
@@ -1137,7 +1137,7 @@ export function registerUploadTests(quench) {
                         it("description", function () {
                             assert.equal(
                                 item.system.description,
-                                "Hearing Group Flash Defense (1 point), Hardened (+1/4)",
+                                "Hearing Group Flash Defense (1 points), Hardened (+1/4)", // Intentionally plural for simpler translation
                             );
                         });
 
@@ -1543,7 +1543,7 @@ export function registerUploadTests(quench) {
                     it("description", function () {
                         assert.equal(
                             item.system.description,
-                            'Teleportation +15" (No Relative Velocity; Position Shift), Reduced Endurance (1/2 END; +1/4)',
+                            'Teleportation 15" (No Relative Velocity; Position Shift), Reduced Endurance (1/2 END; +1/4)',
                         );
                     });
 
@@ -1590,7 +1590,7 @@ export function registerUploadTests(quench) {
                     it("description", function () {
                         assert.equal(
                             item.system.description,
-                            "Teleportation +15m (No Relative Velocity; Position Shift), Reduced Endurance (1/2 END; +1/4)",
+                            "Teleportation 15m (No Relative Velocity; Position Shift), Reduced Endurance (1/2 END; +1/4)",
                         );
                     });
 


### PR DESCRIPTION
- Make upload tests pass again. They broke due to description changes.
- When restoring to full health, only delete temporary effects on an item.