### PR TITLE
Have eslint return failure code to command line

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -21,7 +21,8 @@ function validateFilesByLint() {
     return gulp
         .src(JAVASCRIPT_FILES)
         .pipe(gulpEslintNew(eslintDefaultConfig))
-        .pipe(gulpEslintNew.formatEach("compact", process.stderr));
+        .pipe(gulpEslintNew.formatEach("compact", process.stderr))
+        .pipe(gulpEslintNew.failAfterError());
 }
 const lint = gulp.series(validateFilesByLint);
 


### PR DESCRIPTION
This should resolve the problems with the lint step not rejecting PRs when there is a lint error