### PR TITLE
STUN only roll improvements

### DIFF
--- a/module/item/item-attack.js
+++ b/module/item/item-attack.js
@@ -1069,7 +1069,10 @@ export async function _onRollDamage(event) {
         .addHalfDice(formulaParts.halfDieCount)
         .addNumber(formulaParts.constant)
         .modifyToStandardEffect(useStandardEffect)
-        .modifyToNoBody(item.system.stunBodyDamage === "stunonly")
+        .modifyToNoBody(
+            item.system.stunBodyDamage === "stunonly" ||
+                item.system.stunBodyDamage === "effectonly",
+        )
         .addToHitLocation(includeHitLocation, toHitData.aim);
 
     await heroRoller.roll();

--- a/module/item/item-attack.js
+++ b/module/item/item-attack.js
@@ -1069,6 +1069,7 @@ export async function _onRollDamage(event) {
         .addHalfDice(formulaParts.halfDieCount)
         .addNumber(formulaParts.constant)
         .modifyToStandardEffect(useStandardEffect)
+        .modifyToNoBody(item.system.stunBodyDamage === "stunonly")
         .addToHitLocation(includeHitLocation, toHitData.aim);
 
     await heroRoller.roll();

--- a/module/item/item.js
+++ b/module/item/item.js
@@ -3083,22 +3083,6 @@ export class HeroSystem6eItem extends Item {
         if (stunOnly) {
             this.system.stunBodyDamage = "stunonly";
         }
-
-        // if (item._id) {
-        //     await item.update(changes, { hideChatMessage: true })
-        // }
-
-        // Possibly a QUENCH test
-        // for (let change of Object.keys(changes).filter(o => o != "_id")) {
-        //     let target = item;
-        //     for (let key of change.split('.')) {
-        //         if (typeof target[key] == 'object') {
-        //             target = target[key]
-        //         } else {
-        //             target[key] = changes[change]
-        //         }
-        //     }
-        // }
     }
 
     skillRollUpdateValue() {

--- a/module/item/item.js
+++ b/module/item/item.js
@@ -3083,6 +3083,11 @@ export class HeroSystem6eItem extends Item {
         if (stunOnly) {
             this.system.stunBodyDamage = "stunonly";
         }
+
+        const doesBody = this.findModsByXmlid("DOESBODY");
+        if (doesBody) {
+            this.system.stunBodyDamage = "stunbody";
+        }
     }
 
     skillRollUpdateValue() {

--- a/module/testing/testing-dice.js
+++ b/module/testing/testing-dice.js
@@ -1690,12 +1690,114 @@ export function registerDiceTests(quench) {
                         );
                     });
 
-                    it("should clamp decreased stun multiplier to a minimum of 1", async function () {
+                    it("should clamp decreased stun multiplier at 2 levels (which means always 1 STUNx) for 6e", async function () {
                         const TestRollMock = Roll6Mock;
 
                         const roller = new HeroRoller({}, TestRollMock)
                             .makeKillingRoll(true)
-                            .addStunMultiplier(-7)
+                            .addStunMultiplier(-2)
+                            .addDice(3);
+
+                        await roller.roll();
+
+                        expect(roller.getBodyTerms()).deep.to.equal([
+                            TestRollMock.fixedRollResult,
+                            TestRollMock.fixedRollResult,
+                            TestRollMock.fixedRollResult,
+                        ]);
+                        expect(roller.getBodyTotal()).to.equal(
+                            3 * TestRollMock.fixedRollResult,
+                        );
+
+                        expect(roller.getStunMultiplier()).to.equal(1);
+
+                        expect(roller.getStunTerms()).deep.to.equal([
+                            TestRollMock.fixedRollResult * 1,
+                            TestRollMock.fixedRollResult * 1,
+                            TestRollMock.fixedRollResult * 1,
+                        ]);
+                        expect(roller.getStunTotal()).deep.to.equal(
+                            3 * TestRollMock.fixedRollResult * 1,
+                        );
+                    });
+
+                    it("should clamp decreased stun multiplier at 2 levels (which means always 1 STUNx) for 6e", async function () {
+                        const TestRollMock = Roll6Mock;
+
+                        const roller = new HeroRoller({}, TestRollMock)
+                            .makeKillingRoll(true)
+                            .addStunMultiplier(-3)
+                            .addDice(3);
+
+                        await roller.roll();
+
+                        expect(roller.getBodyTerms()).deep.to.equal([
+                            TestRollMock.fixedRollResult,
+                            TestRollMock.fixedRollResult,
+                            TestRollMock.fixedRollResult,
+                        ]);
+                        expect(roller.getBodyTotal()).to.equal(
+                            3 * TestRollMock.fixedRollResult,
+                        );
+
+                        expect(roller.getStunMultiplier()).to.equal(1);
+
+                        expect(roller.getStunTerms()).deep.to.equal([
+                            TestRollMock.fixedRollResult * 1,
+                            TestRollMock.fixedRollResult * 1,
+                            TestRollMock.fixedRollResult * 1,
+                        ]);
+                        expect(roller.getStunTotal()).deep.to.equal(
+                            3 * TestRollMock.fixedRollResult * 1,
+                        );
+                    });
+
+                    it("should support decreased stun multiplier at 1 level for 5e", async function () {
+                        const TestRollMock = Roll6Mock;
+
+                        const roller = new HeroRoller({}, TestRollMock)
+                            .makeKillingRoll(true)
+                            .modifyTo5e(true)
+                            .addStunMultiplier(-1)
+                            .addDice(3);
+
+                        await roller.roll();
+
+                        expect(roller.getBodyTerms()).deep.to.equal([
+                            TestRollMock.fixedRollResult,
+                            TestRollMock.fixedRollResult,
+                            TestRollMock.fixedRollResult,
+                        ]);
+                        expect(roller.getBodyTotal()).to.equal(
+                            3 * TestRollMock.fixedRollResult,
+                        );
+
+                        expect(roller.getStunMultiplier()).to.equal(
+                            TestRollMock.fixedRollResult - 1 - 1,
+                        );
+
+                        expect(roller.getStunTerms()).deep.to.equal([
+                            TestRollMock.fixedRollResult *
+                                (TestRollMock.fixedRollResult - 1 - 1),
+                            TestRollMock.fixedRollResult *
+                                (TestRollMock.fixedRollResult - 1 - 1),
+                            TestRollMock.fixedRollResult *
+                                (TestRollMock.fixedRollResult - 1 - 1),
+                        ]);
+                        expect(roller.getStunTotal()).deep.to.equal(
+                            3 *
+                                TestRollMock.fixedRollResult *
+                                (TestRollMock.fixedRollResult - 1 - 1),
+                        );
+                    });
+
+                    it("should clamp decreased stun multiplier at 4 levels (which means always 1 STUNx) for 5e", async function () {
+                        const TestRollMock = Roll6Mock;
+
+                        const roller = new HeroRoller({}, TestRollMock)
+                            .makeKillingRoll(true)
+                            .modifyTo5e(true)
+                            .addStunMultiplier(-5)
                             .addDice(3);
 
                         await roller.roll();

--- a/module/testing/testing-dice.js
+++ b/module/testing/testing-dice.js
@@ -1277,6 +1277,31 @@ export function registerDiceTests(quench) {
 
                         expect(roller.getFormula()).to.equal("½d6");
                     });
+
+                    it("should support STUN only", async function () {
+                        const TestRollMock = Roll6Mock;
+
+                        const roller = new HeroRoller({}, TestRollMock)
+                            .makeNormalRoll()
+                            .modifyToNoBody()
+                            .addHalfDice(1)
+                            .addDice(2)
+                            .addNumber(1);
+
+                        await roller.roll();
+
+                        expect(roller.getStunTerms()).to.deep.equal([
+                            3, 6, 6, 1,
+                        ]);
+                        expect(roller.getStunTotal()).to.deep.equal(16);
+
+                        expect(roller.getBodyTerms()).to.deep.equal([
+                            0, 0, 0, 0,
+                        ]);
+                        expect(roller.getBodyTotal()).to.deep.equal(0);
+
+                        expect(roller.getFormula()).to.equal("½d6 + 2d6 + 1");
+                    });
                 });
 
                 describe("killing roll", function () {


### PR DESCRIPTION
- Don't show conflicting `stun only` and `does body` attack tags
- Don't show BODY rolls when attack is `stun only` or `effect only`
- Add `does body` support for mental attacks