### PR TITLE
Adjustment fix for pd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Healing should now work as expected from 1 source. It can no longer increase above the core value. Nor can adjustment powers with only restores to starting value. [#649](https://github.com/dmdorman/hero6e-foundryvtt/issues/649)
 - Implement basic automatic absorption.
 - Fix combat tracker where changing combatant SPD caused issues. Initiative is now DEX.SPD instead of DEX.INT. [#736](https://github.com/dmdorman/hero6e-foundryvtt/issues/736)
+- Adjustment powers now prefer characteristics over powers with the same name. [#747](https://github.com/dmdorman/hero6e-foundryvtt/issues/747)
 
 ## Version 3.0.58
 

--- a/module/herosystem6e.js
+++ b/module/herosystem6e.js
@@ -545,10 +545,10 @@ Hooks.on("updateWorldTime", async (worldTime, options) => {
                 if (game.user.isGM) await actor.addActiveEffect(activeEffect);
             }
 
+            let adjustmentChatMessages = [];
+
             // Active Effects
             for (const ae of actor.temporaryEffects) {
-                let adjustmentChatMessages = [];
-
                 // Determine XMLID, ITEM, ACTOR
                 let origin = await fromUuid(ae.origin);
                 let item = origin instanceof HeroSystem6eItem ? origin : null;
@@ -653,9 +653,10 @@ Hooks.on("updateWorldTime", async (worldTime, options) => {
                         }
                     }
                 }
-
-                await renderAdjustmentChatCards(adjustmentChatMessages);
             }
+
+            await renderAdjustmentChatCards(adjustmentChatMessages);
+            adjustmentChatMessages = [];
 
             // Out of combat recovery.  When SimpleCalendar is used to advance time.
             // This simple routine only handles increments of 12 seconds or more.

--- a/module/utility/adjustment.js
+++ b/module/utility/adjustment.js
@@ -555,8 +555,8 @@ export async function performAdjustment(
         thisAttackEffectiveAdjustmentActivePoints = min;
     }
 
-    // New total.
-    let totalAdjustmentNewActivePoints = isOnlyToStartingValues
+    // New effect total.
+    const totalAdjustmentNewActivePoints = isOnlyToStartingValues
         ? thisAttackEffectiveAdjustmentActivePoints +
           activeEffect.flags.adjustmentActivePoints
         : thisAttackEffectiveAdjustmentActivePoints;
@@ -654,7 +654,6 @@ export async function performAdjustment(
     }
 
     // Calculate the effect value(s)
-    // TODO: Pretty sure recovery isn't working as expected for defensive items
     const newValue =
         totalActivePointAffectedDifference > 0
             ? Math.max(
@@ -714,7 +713,7 @@ function _generateAdjustmentChatCard(
     activePointEffectLostDueToMax,
     activePointEffectLostDueToNotExceeding,
     defenseDescription,
-    potentialCharacteristic, // TODO: Power?
+    targetCharOrPower,
     isFade,
     isEffectFinished,
     targetActor,
@@ -727,7 +726,7 @@ function _generateAdjustmentChatCard(
         adjustment: {
             adjustmentDamageRaw: activePointDamage,
             adjustmentDamageThisApplication: activePointAffectedDifference,
-            adjustmentTarget: potentialCharacteristic.toUpperCase(),
+            adjustmentTarget: targetCharOrPower.toUpperCase(),
             adjustmentTotalActivePointEffect: totalActivePointEffect,
             activePointEffectLostDueToMax,
             activePointEffectLostDueToNotExceeding,

--- a/module/utility/adjustment.js
+++ b/module/utility/adjustment.js
@@ -412,13 +412,16 @@ export async function performAdjustment(
     const targetPower = targetActor.items.find(
         (item) => item.system.XMLID === targetUpperCaseName,
     );
-    const targetCharacteristic =
-        targetActor.system.characteristics?.[potentialCharacteristic];
 
-    // A target we understand?
-    // TODO: Targeting a movement power that the targetActor doesn't have will still succeed. This seems wrong.
+    // Find a matching characteristic. Because movement powers are unfortunately setup as
+    // characteristics, we need to check that they effectively exist.
+    const targetCharacteristic =
+        targetActor.system.characteristics?.[potentialCharacteristic]?.core > 0
+            ? targetActor.system.characteristics?.[potentialCharacteristic]
+            : undefined;
+
+    // Do we have a target?
     if (!targetCharacteristic && !targetPower) {
-        // Can't find anything to link this against.
         return;
     }
 

--- a/module/utility/adjustment.js
+++ b/module/utility/adjustment.js
@@ -330,7 +330,7 @@ function _createNewAdjustmentEffect(
     // TODO: Add a document field
     const activeEffect = {
         name: `${item.system.XMLID || "undefined"} 0 ${
-            (potentialCharacteristic || powerTargetName?.name).toUpperCase() // TODO: This will need to change for multiple effects
+            (potentialCharacteristic || powerTargetName?.name)?.toUpperCase() // TODO: This will need to change for multiple effects
         } (0 AP) [by ${item.actor.name || "undefined"}]`,
         id: `${item.system.XMLID}.${item.id}.${
             potentialCharacteristic || powerTargetName?.name // TODO: This will need to change for multiple effects
@@ -629,7 +629,7 @@ export async function performAdjustment(
         totalActivePointsThatShouldBeAffected,
     )} ${(
         potentialCharacteristic || targetPower?.name
-    ).toUpperCase()} (${Math.abs(totalAdjustmentNewActivePoints)} AP) [by ${
+    )?.toUpperCase()} (${Math.abs(totalAdjustmentNewActivePoints)} AP) [by ${
         item.actor.name || "undefined"
     }]`;
 


### PR DESCRIPTION
- Prefer adjusting characteristic over power when XMLID matches. Resolves #747.
- Recombine fades again.
- Don't allow adjustment of non purchased movement powers, like tunneling, since they always exist but with `core` of 0.