### PR TITLE
Correct STUN for KA when hit locations enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@
 - Initial support for WELL_CONNECTED perk enhancer.
 - Color coded diced based on purpose are now shown if using the Dice So Nice! module. The purpose of each extra dice's color can be seen in Dice So Nice! configuration under theme. (**only visible if alpha testing enabled**)
 - Extra dice (stun multiplier, hit location, and hit location side) are only shown when actually required for automation support. [#793](https://github.com/dmdorman/hero6e-foundryvtt/issues/793)
-
 - Hit location and hit location side dice roll results can now been seen in the dice roll tooltip.
 - Can now aim for a location and side (e.g. left arm) when hit location and individual body part damage tracking are selected.
+- Killing attack STUN should now be correct when using hit locations. [#824](https://github.com/dmdorman/hero6e-foundryvtt/issues/824)
 
 ## Version 3.0.63
 

--- a/module/item/item-attack.mjs
+++ b/module/item/item-attack.mjs
@@ -2106,7 +2106,6 @@ async function _calcDamage(heroRoller, item, options) {
     // -------------------------------------------------
 
     if (itemData.killing) {
-        // TODO: there is only defense against STUN from KA if there is at least some resistant defense
         stun =
             stun - (options.defenseValue || 0) - (options.resistantValue || 0);
         body = body - (options.resistantValue || 0);
@@ -2131,12 +2130,11 @@ async function _calcDamage(heroRoller, item, options) {
             heroRoller.getHitLocation().stunMultiplier;
 
         if (itemData.killing) {
-            // killing attacks apply hit location multiplier after resistant damage protection has been subtracted
+            // Killing attacks apply hit location multiplier after resistant damage protection has been subtracted
             // Location : [x Stun, x N Stun, x Body, OCV modifier]
-            // TODO: Should this also be round down?
-            body = body * hitLocationBodyMultiplier;
+            body = RoundFavorPlayerDown(body * hitLocationBodyMultiplier);
         } else {
-            // stun attacks apply N STUN hit location multiplier after defenses
+            // stun attacks apply N STUN hit location and BODY multiplier after defenses have been subtracted
             stun = RoundFavorPlayerDown(stun * hitLocationStunMultiplier);
             body = RoundFavorPlayerDown(body * hitLocationBodyMultiplier);
         }

--- a/module/testing/testing-dice.mjs
+++ b/module/testing/testing-dice.mjs
@@ -1055,7 +1055,7 @@ export function registerDiceTests(quench) {
                             name: "Foot",
                             side: "none",
                             fullName: "Foot",
-                            stunMultiplier: 0.5,
+                            stunMultiplier: 1,
                             bodyMultiplier: 0.5,
                         });
                     });
@@ -1108,7 +1108,7 @@ export function registerDiceTests(quench) {
                         });
                     });
 
-                    it("should work with guaranteed hit location", async function () {
+                    it("should work with a guaranteed hit location", async function () {
                         const TestRollMock = Roll1Mock;
 
                         const roller = new HeroRoller({}, TestRollMock)
@@ -1127,12 +1127,12 @@ export function registerDiceTests(quench) {
                             name: "Foot",
                             side: "none",
                             fullName: "Foot",
-                            stunMultiplier: 0.5,
+                            stunMultiplier: 1,
                             bodyMultiplier: 0.5,
                         });
                     });
 
-                    it("should work with guaranteed hit location but no hit side", async function () {
+                    it("should work with a guaranteed hit location but no hit side", async function () {
                         const TestRollMock = Roll1Mock;
 
                         const roller = new HeroRoller({}, TestRollMock)
@@ -1151,12 +1151,12 @@ export function registerDiceTests(quench) {
                             name: "Foot",
                             side: "none",
                             fullName: "Foot",
-                            stunMultiplier: 0.5,
+                            stunMultiplier: 1,
                             bodyMultiplier: 0.5,
                         });
                     });
 
-                    it("should work with guaranteed hit location and hit side", async function () {
+                    it("should work with a guaranteed hit location and hit side", async function () {
                         const TestRollMock = Roll1Mock;
 
                         const roller = new HeroRoller({}, TestRollMock)
@@ -1175,7 +1175,7 @@ export function registerDiceTests(quench) {
                             name: "Foot",
                             side: "Right",
                             fullName: "Right Foot",
-                            stunMultiplier: 0.5,
+                            stunMultiplier: 1,
                             bodyMultiplier: 0.5,
                         });
                     });
@@ -2024,12 +2024,13 @@ export function registerDiceTests(quench) {
                         });
                     });
 
-                    it("should use hit location and not increased stun multiplier with killing attacks", async function () {
+                    it("should use hit location with increased stun multiplier with killing attacks", async function () {
                         const TestRollMock = Roll6Mock;
+                        const increasedStunMultiplier = 7;
 
                         const roller = new HeroRoller({}, TestRollMock)
                             .makeKillingRoll(true)
-                            .addStunMultiplier(7)
+                            .addStunMultiplier(increasedStunMultiplier)
                             .addToHitLocation()
                             .addDice(3);
 
@@ -2047,12 +2048,17 @@ export function registerDiceTests(quench) {
                         expect(() => roller.getStunMultiplier()).to.throw();
 
                         expect(roller.getStunTerms()).deep.to.equal([
-                            1 * TestRollMock.fixedRollResult,
-                            1 * TestRollMock.fixedRollResult,
-                            1 * TestRollMock.fixedRollResult,
+                            (1 + increasedStunMultiplier) *
+                                TestRollMock.fixedRollResult,
+                            (1 + increasedStunMultiplier) *
+                                TestRollMock.fixedRollResult,
+                            (1 + increasedStunMultiplier) *
+                                TestRollMock.fixedRollResult,
                         ]);
                         expect(roller.getStunTotal()).deep.to.equal(
-                            3 * 1 * TestRollMock.fixedRollResult,
+                            3 *
+                                (1 + increasedStunMultiplier) *
+                                TestRollMock.fixedRollResult,
                         );
                         const hitLocation = roller.getHitLocation();
                         expect(hitLocation).to.deep.equal({
@@ -2064,7 +2070,7 @@ export function registerDiceTests(quench) {
                         });
                     });
 
-                    it("should use hit location and not decreased stun multiplier with killing attacks", async function () {
+                    it("should use hit location with decreased stun multiplier (floor 1) with killing attacks", async function () {
                         const TestRollMock = Roll6Mock;
 
                         const roller = new HeroRoller({}, TestRollMock)
@@ -2099,7 +2105,7 @@ export function registerDiceTests(quench) {
                             name: "Foot",
                             side: "none",
                             fullName: "Foot",
-                            stunMultiplier: 0,
+                            stunMultiplier: 1,
                             bodyMultiplier: 0.5,
                         });
                     });

--- a/module/utility/dice.mjs
+++ b/module/utility/dice.mjs
@@ -1158,7 +1158,8 @@ export class HeroRoller {
 
             case HeroRoller.ROLL_TYPE.KILLING:
                 if (this._useHitLocation) {
-                    return adjustedResult;
+                    // Use the hit location STUNx
+                    return adjustedResult * this._hitLocation.stunMultiplier;
                 }
 
                 return adjustedResult * this.getBaseMultiplier();

--- a/module/utility/dice.mjs
+++ b/module/utility/dice.mjs
@@ -1089,7 +1089,7 @@ export class HeroRoller {
                         ? `${locationSide} ${locationName}`
                         : locationName,
                 stunMultiplier: Math.max(
-                    0,
+                    1,
                     (this._type === HeroRoller.ROLL_TYPE.KILLING
                         ? CONFIG.HERO.hitLocations[locationName][0]
                         : CONFIG.HERO.hitLocations[locationName][1]) +


### PR DESCRIPTION
- Correct decreased stun multiplier (the minimum STUNx is 1)
- Correct STUN calculation for KA when hit locations enabled by including them in the dice rolls (resolves #824)