### PR TITLE
Penetrating damage occurs before minimum damage calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - For odd time you don't want to count the result of a manual dice roll, `/heroroll` in chat is now a command. See [README.md](https://github.com/dmdorman/hero6e-foundryvtt/blob/main/README.md) for details.
 - Correct Find Weakness' and Danger Sense description and costing.
 - Add success rolls icon to the actor's sheet powers tab.
+- Minimum damage calculation should be last in the damage application chain to allow penetrating killing attacks to do STUN >= BODY.
 
 ## Version 3.0.64
 

--- a/module/item/item-attack.mjs
+++ b/module/item/item-attack.mjs
@@ -2178,17 +2178,6 @@ async function _calcDamage(heroRoller, item, options) {
         );
     }
 
-    // minimum damage rule
-    if (stun < body) {
-        stun = body;
-        effects +=
-            `minimum damage invoked <i class="fal fa-circle-info" data-tooltip="` +
-            `<b>MINIMUM DAMAGE FROM INJURIES</b><br>` +
-            `Characters take at least 1 STUN for every 1 point of BODY
-             damage that gets through their defenses.` +
-            `"></i> `;
-    }
-
     // Penetrating attack minimum damage
     if (itemData.killing && penetratingBody > body) {
         body = penetratingBody;
@@ -2196,6 +2185,17 @@ async function _calcDamage(heroRoller, item, options) {
     } else if (!itemData.killing && penetratingBody > stun) {
         stun = penetratingBody;
         effects += "penetrating damage; ";
+    }
+
+    // minimum damage rule (needs to be last)
+    if (stun < body) {
+        stun = body;
+        effects +=
+            `minimum damage invoked <i class="fal fa-circle-info" data-tooltip="` +
+            `<b>MINIMUM DAMAGE FROM INJURIES</b><br>` +
+            `Characters take at least 1 STUN for every 1 point of BODY
+                 damage that gets through their defenses.` +
+            `"></i> `;
     }
 
     // Special effects that change damage?


### PR DESCRIPTION
- swap the order of penetrating and minimum damage in the damage pipeline