### PR TITLE
5e velocity maneuvers

### DIFF
--- a/module/actor/actor-sheet.mjs
+++ b/module/actor/actor-sheet.mjs
@@ -16,7 +16,7 @@ import {
 } from "../utility/damage.mjs";
 import { HeroRoller } from "../utility/dice.mjs";
 import { getSystemDisplayUnits } from "../utility/units.mjs";
-import { calculateVelocity } from "../ruler.mjs";
+import { calculateVelocityInSystemUnits } from "../ruler.mjs";
 
 export class HeroSystemActorSheet extends ActorSheet {
     /** @override */
@@ -197,7 +197,7 @@ export class HeroSystemActorSheet extends ActorSheet {
 
                                 const tokens = item.actor.getActiveTokens();
                                 const token = tokens[0];
-                                const velocity = calculateVelocity(
+                                const velocity = calculateVelocityInSystemUnits(
                                     item.actor,
                                     token,
                                 );

--- a/module/actor/actor-sheet.mjs
+++ b/module/actor/actor-sheet.mjs
@@ -16,6 +16,7 @@ import {
 } from "../utility/damage.mjs";
 import { HeroRoller } from "../utility/dice.mjs";
 import { getSystemDisplayUnits } from "../utility/units.mjs";
+import { calculateVelocity } from "../ruler.mjs";
 
 export class HeroSystemActorSheet extends ActorSheet {
     /** @override */
@@ -194,68 +195,12 @@ export class HeroSystemActorSheet extends ActorSheet {
                                     "+" + parseInt(item.system.ocv)
                                 ).replace("+-", "-");
 
-                                let velocity = 0;
-
-                                // Velocity from drag ruler
                                 const tokens = item.actor.getActiveTokens();
                                 const token = tokens[0];
-                                const combatants = game?.combat?.combatants;
-                                if (
-                                    combatants &&
-                                    typeof dragRuler != "undefined"
-                                ) {
-                                    if (token) {
-                                        let distance =
-                                            dragRuler.getMovedDistanceFromToken(
-                                                token,
-                                            );
-                                        let ranges =
-                                            dragRuler.getRangesFromSpeedProvider(
-                                                token,
-                                            );
-                                        let speed =
-                                            ranges.length > 1
-                                                ? ranges[1].range
-                                                : 0;
-                                        let delta = distance;
-                                        if (delta > speed / 2) {
-                                            delta = speed - delta;
-                                        }
-                                        velocity = delta * 5;
-                                    }
-                                }
-
-                                // Simplistic velocity calc using dragRuler
-                                if (velocity === 0 && token) {
-                                    if (typeof dragRuler != "undefined") {
-                                        if (
-                                            dragRuler.getRangesFromSpeedProvider(
-                                                token,
-                                            ).length > 1
-                                        ) {
-                                            velocity = parseInt(
-                                                dragRuler.getRangesFromSpeedProvider(
-                                                    token,
-                                                )[1].range || 0,
-                                            );
-                                        }
-                                    }
-                                }
-
-                                // Simplistic velocity calc using running & flight
-                                if (velocity === 0) {
-                                    velocity = parseInt(
-                                        item.actor.system.characteristics
-                                            .running.value || 0,
-                                    );
-                                    velocity = Math.max(
-                                        velocity,
-                                        parseInt(
-                                            item.actor.system.characteristics
-                                                .flight.value || 0,
-                                        ),
-                                    );
-                                }
+                                const velocity = calculateVelocity(
+                                    item.actor,
+                                    token,
+                                );
 
                                 item.system.ocvEstimated = (
                                     parseInt(csl.ocv) + parseInt(velocity / 10)

--- a/module/combat.mjs
+++ b/module/combat.mjs
@@ -558,8 +558,6 @@ export class HeroSystem6eCombat extends Combat {
             );
             await effect.delete();
         }
-
-        //console.log("_onStartTurn.end", combatant.name, this.current);
     }
 
     /**
@@ -572,61 +570,6 @@ export class HeroSystem6eCombat extends Combat {
      * @protected
      */
     async _onEndTurn(combatant) {
-        //console.log("_onEndTurn", combatant.name, this.current);
-
-        // const automation = game.settings.get(
-        //     "hero6efoundryvttv2",
-        //     "automation",
-        // );
-
-        // https://github.com/dmdorman/hero6e-foundryvtt/issues/722
-        // if (this.round > 0) {
-        //     // Edge case where Flight was using 1 END when combat begins.  Make sure that doesn't happen.
-        //     // Hover (flight) uses 1 END
-        //     if (
-        //         automation === "all" ||
-        //         (automation === "npcOnly" && combatant.actor.type == "npc") ||
-        //         (automation === "pcEndOnly" && combatant.actor.type === "pc")
-        //     ) {
-        //         if (
-        //             // gliding costs no endurance
-        //             ["flight"].includes(combatant.actor?.flags?.activeMovement)
-        //         ) {
-        //             //console.log(combatant.actor);
-        //             if (dragRuler?.getRangesFromSpeedProvider) {
-        //                 if (
-        //                     dragRuler.getMovedDistanceFromToken(
-        //                         combatant.token.object,
-        //                     ) === 0
-        //                 ) {
-        //                     let endValue =
-        //                         parseInt(
-        //                             combatant.actor.system.characteristics.end
-        //                                 .value,
-        //                         ) - 1;
-        //                     await combatant.actor.update({
-        //                         "system.characteristics.end.value": endValue,
-        //                     });
-
-        //                     // ChatCard notification about spending 1 END to hover.
-        //                     // Players may mistakenly leave FLIGHT on.
-        //                     const content = `${combatant.token.name} spent 1 END to hover.`;
-        //                     const chatData = {
-        //                         user: game.user.id,
-        //                         //whisper: ChatMessage.getWhisperRecipients("GM"),
-        //                         speaker: ChatMessage.getSpeaker({
-        //                             actor: combatant.actor,
-        //                         }),
-        //                         //blind: true,
-        //                         content: content,
-        //                     };
-        //                     await ChatMessage.create(chatData);
-        //                 }
-        //             }
-        //         }
-        //     }
-        // }
-
         super._onEndTurn(combatant);
 
         // At the end of the Segment, any non-Persistent Powers, and any Skill Levels of any type, turn off for STUNNED actors.
@@ -634,11 +577,6 @@ export class HeroSystem6eCombat extends Combat {
             this.turns?.[this.turn]?.flags.segment !=
             this.turns?.[this.turn - 1]?.flags.segment
         ) {
-            //console.log(
-            //     "next segment",
-            //     this.combatant.flags?.segment,
-            //     this.current,
-            // );
             for (let _combatant of this.combatants) {
                 if (
                     _combatant?.actor?.statuses.has("stunned") ||
@@ -685,8 +623,6 @@ export class HeroSystem6eCombat extends Combat {
      * @protected
      */
     async _onEndRound() {
-        //console.log("_onEndRound", this.current);
-
         super._onEndRound();
 
         // Make really sure we only call at the end of the round
@@ -810,10 +746,9 @@ export class HeroSystem6eCombat extends Combat {
      * @returns {Promise<Combat>}
      */
     async startCombat() {
-        //console.log("startCombat", this.current);
-
         // Don't call super because we start on segment 12 which is never turn 0.
         //await super.startCombat();
+
         this._playCombatSound("startEncounter");
         const turn = this.turns.findIndex((o) => o.flags.segment === 12) || 1;
         const updateData = {
@@ -823,22 +758,6 @@ export class HeroSystem6eCombat extends Combat {
         };
         Hooks.callAll("combatStart", this, updateData);
         await this.update(updateData);
-
-        // Reset all movement history when we start combat
-        // if (dragRuler) {
-        //     for (const _combatant of this.combatants) {
-        //         await dragRuler.resetMovementHistory(this, _combatant.id);
-        //     }
-        // }
-
-        //this.setupTurns();
-
-        // Find first TURN with segment 12
-        // let turn = this.turns.findIndex((o) => o.flags.segment === 12) || 1;
-
-        // const updateData = { round: 1, turn: turn };
-        // await this.update(updateData);
-        //console.log("startCombat.end", this.current);
     }
 
     /**

--- a/module/item/item-attack-application.mjs
+++ b/module/item/item-attack-application.mjs
@@ -169,7 +169,9 @@ export class ItemAttackFormApplication extends FormApplication {
 
         this.data.ocvMod = formData.ocvMod;
         this.data.dcvMod = formData.dcvMod;
+
         this.data.effectiveStr = formData.effectiveStr;
+
         this.data.boostableCharges = Math.max(
             0,
             Math.min(
@@ -177,6 +179,8 @@ export class ItemAttackFormApplication extends FormApplication {
                 this.data.item.charges?.value - 1,
             ),
         );
+
+        this.data.velocity = parseInt(formData.velocity || 0);
 
         // Show any changes
         this.render();

--- a/module/item/item-attack.mjs
+++ b/module/item/item-attack.mjs
@@ -15,7 +15,7 @@ import { getSystemDisplayUnits } from "../utility/units.mjs";
 import { RequiresASkillRollCheck } from "../item/item.mjs";
 import { ItemAttackFormApplication } from "../item/item-attack-application.mjs";
 import { HeroRoller } from "../utility/dice.mjs";
-import { calculateVelocity } from "../ruler.mjs";
+import { calculateVelocityInSystemUnits } from "../ruler.mjs";
 
 export async function chatListeners(html) {
     html.on("click", "button.roll-damage", this._onRollDamage.bind(this));
@@ -82,7 +82,7 @@ export async function AttackOptions(item) {
         const token = tokens[0];
 
         data.showVelocity = true;
-        data.velocity = calculateVelocity(item.actor, token);
+        data.velocity = calculateVelocityInSystemUnits(item.actor, token);
     }
 
     const aoe = item.getAoeModifier();

--- a/module/item/item-attack.mjs
+++ b/module/item/item-attack.mjs
@@ -76,8 +76,7 @@ export async function AttackOptions(item) {
 
     // Maneuvers and Martial attacks may include velocity
     // [NORMALDC] +v/5 Strike, FMove
-    if ((item.system.EFFECT || "").match(/v\/\d/)) {
-        //["MOVEBY", "MOVETHROUGH"].includes(item.system.XMLID)) {
+    if ((item.system.EFFECT || "").match(/v\/\d+/)) {
         data.showVelocity = true;
         data.velocity = 0;
 

--- a/module/item/item-attack.mjs
+++ b/module/item/item-attack.mjs
@@ -15,6 +15,7 @@ import { getSystemDisplayUnits } from "../utility/units.mjs";
 import { RequiresASkillRollCheck } from "../item/item.mjs";
 import { ItemAttackFormApplication } from "../item/item-attack-application.mjs";
 import { HeroRoller } from "../utility/dice.mjs";
+import { calculateVelocity } from "../ruler.mjs";
 
 export async function chatListeners(html) {
     html.on("click", "button.roll-damage", this._onRollDamage.bind(this));
@@ -77,47 +78,11 @@ export async function AttackOptions(item) {
     // Maneuvers and Martial attacks may include velocity
     // [NORMALDC] +v/5 Strike, FMove
     if ((item.system.EFFECT || "").match(/v\/\d+/)) {
-        data.showVelocity = true;
-        data.velocity = 0;
-
         const tokens = item.actor.getActiveTokens();
         const token = tokens[0];
-        const combatants = game?.combat?.combatants;
-        if (combatants && typeof dragRuler != "undefined") {
-            if (token) {
-                let distance = dragRuler.getMovedDistanceFromToken(token);
-                let speed =
-                    dragRuler.getRangesFromSpeedProvider(token)[1].range;
-                let delta = distance;
-                if (delta > speed / 2) {
-                    delta = speed - delta;
-                }
-                data.velocity = delta * 5;
-            }
-        }
 
-        // Simplistic velocity calc using dragRuler
-        if (data.velocity === 0 && token) {
-            if (typeof dragRuler != "undefined") {
-                if (dragRuler.getRangesFromSpeedProvider(token).length > 1) {
-                    data.velocity = parseInt(
-                        dragRuler.getRangesFromSpeedProvider(token)[1].range ||
-                            0,
-                    );
-                }
-            }
-        }
-
-        // Simplistic velocity calc using running & flight
-        if (data.velocity === 0) {
-            data.velocity = parseInt(
-                item.actor.system.characteristics.running.value || 0,
-            );
-            data.velocity = Math.max(
-                data.velocity,
-                parseInt(item.actor.system.characteristics.flight.value || 0),
-            );
-        }
+        data.showVelocity = true;
+        data.velocity = calculateVelocity(item.actor, token);
     }
 
     const aoe = item.getAoeModifier();

--- a/module/ruler.mjs
+++ b/module/ruler.mjs
@@ -137,8 +137,8 @@ export class HeroRuler {
                                 );
 
                                 // TODO: We are using getMovedDistanceFromToken to get total distance,
-                                // however, we really should seperate distances by activeMovement so
-                                // we can apply END modificaitons to specific movements.
+                                // however, we really should separate distances by activeMovement so
+                                // we can apply END modifications to specific movements.
                                 // This is only an issue with split movement types.
                                 let currentDistance =
                                     dragRuler.getMovedDistanceFromToken(
@@ -185,7 +185,7 @@ export class HeroRuler {
                                         ) || 1;
                                 }
 
-                                // Assuming every 10 costs 1 endurance
+                                // TODO: This is assuming every 10 costs 1 endurance
                                 let totalEnd = Math.ceil(
                                     currentDistance / DistancePerEnd,
                                 );
@@ -434,4 +434,42 @@ function setHeroRulerLabel() {
 
         return label;
     };
+}
+
+export function calculateVelocity(actor, token) {
+    let velocity = 0;
+
+    const combatants = game?.combat?.combatants;
+
+    if (combatants && typeof dragRuler != "undefined" && token) {
+        const distance = dragRuler.getMovedDistanceFromToken(token);
+        const ranges = dragRuler.getRangesFromSpeedProvider(token);
+        const speed = ranges.length > 1 ? ranges[1].range : 0;
+        let delta = distance;
+        if (delta > speed / 2) {
+            delta = speed - delta;
+        }
+        velocity = delta * 5;
+    }
+
+    // Simplistic velocity calc using dragRuler
+    if (velocity === 0 && typeof dragRuler != "undefined" && token) {
+        if (dragRuler.getRangesFromSpeedProvider(token).length > 1) {
+            velocity = parseInt(
+                dragRuler.getRangesFromSpeedProvider(token)[1].range || 0,
+            );
+        }
+    }
+
+    // Simplistic velocity calc using running & flight
+    // TODO: Should we not at least get the presently enabled movement type(s) to make a guess?
+    if (velocity === 0) {
+        velocity = parseInt(actor.system.characteristics.running.value || 0);
+        velocity = Math.max(
+            velocity,
+            parseInt(actor.system.characteristics.flight.value || 0),
+        );
+    }
+
+    return velocity;
 }

--- a/templates/attack/item-attack-application.hbs
+++ b/templates/attack/item-attack-application.hbs
@@ -52,52 +52,52 @@
     </div>
 
     {{#if showVelocity}}
-    <div class="form-group">
-      <label>{{localize "Items.Attack.Velocity"}}</label>
-      <input type="text" name="velocity" value="{{velocity}}"
-        title="Typically you assume a starting velocity of 0, accelerate up to half your full move, then decelerate back to a 0 velocity.  A character can accelerate at a rate of 5m per meter.  If the Drag Ruler module is enabled, combat has started, and token has moved on its phase, then a velocity estimate is provided.  A simplistic solution is to assume velocity is equal to the movement speed." />
-    </div>
+      <div class="form-group">
+        <label>{{localize "Items.Attack.Velocity"}}</label>
+        <input type="text" name="velocity" value="{{velocity}}"
+          title="Typically you assume a starting velocity of 0, accelerate up to half your full move, then decelerate back to a 0 velocity.  A character can accelerate at a rate of 5m per meter.  If the Drag Ruler module is enabled, combat has started, and token has moved on its phase, then a velocity estimate is provided.  A simplistic solution is to assume velocity is equal to the movement speed." />
+      </div>
     {{/if}}
 
 
     {{#if (or item.system.usesStrength item.system.usesTk)}}
-    <div class="form-group">
-      <label>Effective Strength</label>
-      <input type="text" name="effectiveStr" value="{{effectiveStr}}" />
-      <label>/ {{str}}</label>
-    </div>
+      <div class="form-group">
+        <label>Effective Strength</label>
+        <input type="text" name="effectiveStr" value="{{effectiveStr}}" />
+        <label>/ {{str}}</label>
+      </div>
     {{/if}}
 
     {{#if boostableCharges}}
-    <div class="form-group">
-      <label>Boostable ({{boostableCharges}})</label>
-      <input type="text" name="boostableCharges" value="0" />
-      
-    </div>
+      <div class="form-group">
+        <label>Boostable ({{boostableCharges}})</label>
+        <input type="text" name="boostableCharges" value="0" />
+        
+      </div>
     {{/if}}
 
     {{#if cslChoices}}
-    <div class="form-group">
-      <label>Combat Skill Levels</label>
-      <div class="form-fields combat-skill-levels">
-        <ol>
-          {{#each csl}}
-          <li>
-            {{ radioBoxes this.name @root/cslChoices checked=this.value localize=true}}
-          </li>
-          {{/each}}
-        </ol>
+      <div class="form-group">
+        <label>Combat Skill Levels</label>
+        <div class="form-fields combat-skill-levels">
+          <ol>
+            {{#each csl}}
+            <li>
+              {{ radioBoxes this.name @root/cslChoices checked=this.value localize=true}}
+            </li>
+            {{/each}}
+          </ol>
 
+        </div>
       </div>
-    </div>
     {{/if}}
 
     {{#if aoeText}}
-    <div class="aoe-button flexrow">
-      <button type="submit" name="aoe">
-        Place {{aoeText}} template
-      </button>
-    </div>
+      <div class="aoe-button flexrow">
+        <button type="submit" name="aoe">
+          Place {{aoeText}} template
+        </button>
+      </div>
     {{/if}}
   </div>
 


### PR DESCRIPTION
- Refactor similar velocity calculation code across the code base.
- In new function return velocity in system units rather than metres (resolves #923).
- Tighten up in combat velocity calculations in cases where the combatant hasn't moved.
- Allow the velocity field of the to hit form to be modified in case it's incorrect.
- Fix v/10 cases for velocity calculations by allowing multiple digits in the regexp.