### PR TITLE
fix(aoe template): remove 1/2 system unit in size and fix cone sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Releases
 
+## Version 3.0.69 (So far...) [Hero System 6e (Unofficial) v2](https://github.com/dmdorman/hero6e-foundryvtt)
+
+* Make AOE templates a 1/2 system unit smaller. [#966](https://github.com/dmdorman/hero6e-foundryvtt/issues/966)
+* Cone AOE templates now sized correctly when world is set to flat cone template. [FoundryVTT Measured Template Controls](https://foundryvtt.com/article/measurement/)
+
 ## Version 3.0.68 [Hero System 6e (Unofficial) v2](https://github.com/dmdorman/hero6e-foundryvtt)
 
 - Correct range penalty calculations. [#944](https://github.com/dmdorman/hero6e-foundryvtt/issues/944)

--- a/module/ruler.mjs
+++ b/module/ruler.mjs
@@ -1,6 +1,6 @@
 import { HEROSYS } from "./herosystem6e.mjs";
 import {
-    getRoundedDistanceInSystemUnits,
+    getRoundedDownDistanceInSystemUnits,
     getSystemDisplayUnits,
 } from "./utility/units.mjs";
 
@@ -429,7 +429,10 @@ function setHeroRulerLabel() {
         }
 
         const label = `[${Math.round(
-            getRoundedDistanceInSystemUnits(segmentDistance.distance, actor),
+            getRoundedDownDistanceInSystemUnits(
+                segmentDistance.distance,
+                actor,
+            ),
         )}${getSystemDisplayUnits(actor)}]${
             activeMovementLabel ? `\n${activeMovementLabel}` : ""
         }\n${rangeMod > 0 ? "-" : ""}${rangeMod} Range Modifier`;
@@ -507,7 +510,7 @@ export function calculateRangePenaltyFromDistanceInMetres(
 ) {
     const is5e = actor?.system?.is5e;
     const roundedDistanceInMetres =
-        getRoundedDistanceInSystemUnits(distanceInMetres, actor) *
+        getRoundedDownDistanceInSystemUnits(distanceInMetres, actor) *
         (is5e ? 2 : 1);
     const basicRangePenalty =
         Math.ceil(Math.log2(roundedDistanceInMetres / 8)) * 2;

--- a/module/utility/units.mjs
+++ b/module/utility/units.mjs
@@ -3,20 +3,48 @@ export function getSystemDisplayUnits(actor) {
 }
 
 /**
+ *
+ * @param {object} actor
+ * @returns number
+ */
+export function convertSystemUnitsToMetres(distanceInSystemUnits, actor) {
+    return distanceInSystemUnits * actor?.system?.is5e ? 2 : 1;
+}
+
+/**
  * Return the distance in the nearest rounded down system units.
  * 8.9m is 8m in 6e and 4" in 5e.
  * 9.9m is 9m in 6e and 4" in 5e.
  *
  * @param {number} distanceInMetres
  * @param {object} actor
- * @returns
+ * @returns number
  */
-export function getRoundedDistanceInSystemUnits(distanceInMetres, actor) {
+export function getRoundedDownDistanceInSystemUnits(distanceInMetres, actor) {
     const is5e = actor?.system?.is5e;
 
     const roundedDistanceInMetres = is5e
-        ? Math.floor(distanceInMetres / 2) * 2
+        ? Math.floor(distanceInMetres / 2)
         : Math.floor(distanceInMetres);
 
-    return is5e ? roundedDistanceInMetres / 2 : roundedDistanceInMetres;
+    return roundedDistanceInMetres;
+}
+
+/**
+ * Return the distance in the nearest rounded up system units.
+ * 8.9m is 9m in 6e and 5" in 5e.
+ * 9.9m is 10m in 6e and 5" in 5e.
+ *
+ * @param {number} distanceInMetres
+ * @param {object} actor
+ * @returns number
+ */
+export function getRoundedUpDistanceInSystemUnits(distanceInMetres, actor) {
+    const is5e = actor?.system?.is5e;
+
+    const roundedDistanceInMetres = is5e
+        ? Math.ceil(distanceInMetres / 2)
+        : Math.ceil(distanceInMetres);
+
+    return roundedDistanceInMetres;
 }


### PR DESCRIPTION
resolves #966 

- AOE templates were a 1/2 system unit too large since the first 1"/1m is the hex that the actor is in.
- Cone template was using rounded end. FoundryVTT supports a flat end so get users to use it by printing a warning when they're not.