### PR TITLE
Remove flat cones and pepper with TODOs to match what is required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 ## Version 3.0.69 (So far...) [Hero System 6e (Unofficial) v2](https://github.com/dmdorman/hero6e-foundryvtt)
 
-- Make AOE templates a 1/2 system unit smaller. [#966](https://github.com/dmdorman/hero6e-foundryvtt/issues/966)
-- Cone AOE templates now sized correctly when world is set to flat cone template. [FoundryVTT Measured Template Controls](https://foundryvtt.com/article/measurement/)
+- Correct AOE templates by making a hex smaller. [#966](https://github.com/dmdorman/hero6e-foundryvtt/issues/966)
 - Stop auto success/auto miss for standard AOE target resolution. [#965](https://github.com/dmdorman/hero6e-foundryvtt/issues/965)
-- Initial support for STR MINIMUM. STR is reduced by STR MINIMUM, but no OCV/DC penalties for low STR. [#971](https://github.com/dmdorman/hero6e-foundryvtt/issues/971)
+- Initial support for STR MINIMUM. STR damage is reduced by STR MINIMUM, but no OCV/DC penalties for low STR. [#971](https://github.com/dmdorman/hero6e-foundryvtt/issues/971)
 - Initial support for WEAPON_MASTER talent. [#972](https://github.com/dmdorman/hero6e-foundryvtt/issues/972)
 - Initial support for DEADLYBLOW talent. [#972](https://github.com/dmdorman/hero6e-foundryvtt/issues/972)
 - Initial support for PERSONALIMMUNITY. [#973](https://github.com/dmdorman/hero6e-foundryvtt/issues/973)

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -210,7 +210,7 @@ Our support ratings:
 | ALTERABLE SIZE | D |  |
 | ALTERNATE COMBAT VALUE | C | Works on some attacks |
 | ALWAYS ON | D |  |
-| AREA OF EFFECT | B | Any surface not supported |
+| AREA OF EFFECT | B | Any surface not supported, circle and cone templates not correct when bigger than ~7 hexes |
 | ARMOR PIERCING | A | |
 | ATTACK VERSUS ALTERNATE DEFENSE | D |  |
 | AUTOFIRE | B | Good single target support, poor multiple target support  |


### PR DESCRIPTION
Proper AOE templates are required to make this correct for cone and radius sizes above 7 hexes. Kludge baby kludge.