### PR TITLE
v12 hero roller changes

### DIFF
--- a/module/testing/testing-dice.mjs
+++ b/module/testing/testing-dice.mjs
@@ -1,9 +1,8 @@
 import { HeroRoller } from "../utility/dice.mjs";
 
 // v11/v12 compatibility shim
+// TODO: Cleanup eslint file with these terms
 const Die = CONFIG.Dice.terms.d;
-const NumericTerm = CONFIG.Dice.termTypes.NumericTerm;
-const OperatorTerm = CONFIG.Dice.termTypes.OperatorTerm;
 
 function FixedDieRoll(fixedRollResult) {
     return class extends Die {
@@ -122,7 +121,7 @@ export function registerDiceTests(quench) {
         "hero6efoundryvttv2.utils.dice",
         (context) => {
             const { describe, expect, it } = context;
-            describe("HeroRoller", function () {
+            describe.only("HeroRoller", function () {
                 describe("chaining", function () {
                     it("should be conditional for make functions with negative and default", function () {
                         const roller = new HeroRoller().makeSuccessRoll();
@@ -283,7 +282,7 @@ export function registerDiceTests(quench) {
                         expect(roller.getFormula()).to.equal("0");
                     });
 
-                    it("should handle formulas with numeric term", async function () {
+                    it.only("should handle formulas with numeric term", async function () {
                         const roller = new HeroRoller().addNumber(7);
                         await roller.roll();
 

--- a/module/testing/testing-dice.mjs
+++ b/module/testing/testing-dice.mjs
@@ -121,7 +121,7 @@ export function registerDiceTests(quench) {
         "hero6efoundryvttv2.utils.dice",
         (context) => {
             const { describe, expect, it } = context;
-            describe.only("HeroRoller", function () {
+            describe("HeroRoller", function () {
                 describe("chaining", function () {
                     it("should be conditional for make functions with negative and default", function () {
                         const roller = new HeroRoller().makeSuccessRoll();
@@ -282,7 +282,7 @@ export function registerDiceTests(quench) {
                         expect(roller.getFormula()).to.equal("0");
                     });
 
-                    it.only("should handle formulas with numeric term", async function () {
+                    it("should handle formulas with numeric term", async function () {
                         const roller = new HeroRoller().addNumber(7);
                         await roller.roll();
 

--- a/module/testing/testing-dice.mjs
+++ b/module/testing/testing-dice.mjs
@@ -1,5 +1,10 @@
 import { HeroRoller } from "../utility/dice.mjs";
 
+// v11/v12 compatibility shim
+const Die = CONFIG.Dice.terms.d;
+const NumericTerm = CONFIG.Dice.termTypes.NumericTerm;
+const OperatorTerm = CONFIG.Dice.termTypes.OperatorTerm;
+
 function FixedDieRoll(fixedRollResult) {
     return class extends Die {
         constructor(termData = {}) {

--- a/module/utility/dice.mjs
+++ b/module/utility/dice.mjs
@@ -36,6 +36,11 @@ const DICE_SO_NICE_CUSTOM_SETS = {
 
 const DICE_SO_NICE_CATEGORY_NAME = "Hero System 6e (Unofficial) V2";
 
+// v11/v12 compatibility shim
+const Die = CONFIG.Dice.terms.d;
+const NumericTerm = CONFIG.Dice.termTypes.NumericTerm;
+const OperatorTerm = CONFIG.Dice.termTypes.OperatorTerm;
+
 /**
  * Add colour sets into Dice So Nice! This allows users to see what the colour set is for each function.
  * Players can then choose to use that theme for maximum confusion as to which are their rolls and which

--- a/module/utility/dice.mjs
+++ b/module/utility/dice.mjs
@@ -325,13 +325,15 @@ export class HeroRoller {
             return this;
         }
 
-        this.#addOperatorTerm(numDice > 0 ? "+" : "-");
+        if (this._formulaTerms.length > 0) {
+            this.#addOperatorTerm(numDice > 0 ? "+" : "-");
+        }
 
-        const absNumDice = Math.abs(numDice);
+        numDice = this._formulaTerms.length > 0 ? Math.abs(numDice) : numDice;
         this._formulaTerms.push(
             new Die({
                 faces: 6,
-                number: absNumDice,
+                number: numDice,
                 options: {
                     _hrQualifier: HeroRoller.QUALIFIER.FULL_DIE,
                     flavor: description,
@@ -339,7 +341,7 @@ export class HeroRoller {
                         ? undefined
                         : {
                               name: description,
-                              value: absNumDice,
+                              value: numDice,
                           },
                 },
             }),
@@ -353,13 +355,15 @@ export class HeroRoller {
             return this;
         }
 
-        this.#addOperatorTerm(numDice > 0 ? "+" : "-");
+        if (this._formulaTerms.length > 0) {
+            this.#addOperatorTerm(numDice > 0 ? "+" : "-");
+        }
 
-        const absNumDice = Math.abs(numDice);
+        numDice = this._formulaTerms.length > 0 ? Math.abs(numDice) : numDice;
         this._formulaTerms.push(
             new Die({
                 faces: 6,
-                number: absNumDice,
+                number: numDice,
                 options: {
                     _hrQualifier: HeroRoller.QUALIFIER.HALF_DIE,
                     flavor: description,
@@ -367,7 +371,7 @@ export class HeroRoller {
                         ? undefined
                         : {
                               name: description,
-                              value: absNumDice,
+                              value: numDice,
                           },
                 },
             }),
@@ -381,13 +385,15 @@ export class HeroRoller {
             return this;
         }
 
-        this.#addOperatorTerm(numDice > 0 ? "+" : "-");
+        if (this._formulaTerms.length > 0) {
+            this.#addOperatorTerm(numDice > 0 ? "+" : "-");
+        }
 
-        const absNumDice = Math.abs(numDice);
+        numDice = this._formulaTerms.length > 0 ? Math.abs(numDice) : numDice;
         this._formulaTerms.push(
             new Die({
                 faces: 6,
-                number: absNumDice,
+                number: numDice,
                 options: {
                     _hrQualifier: HeroRoller.QUALIFIER.FULL_DIE_LESS_ONE,
                     flavor: description,
@@ -395,7 +401,7 @@ export class HeroRoller {
                         ? undefined
                         : {
                               name: description,
-                              value: absNumDice,
+                              value: numDice,
                           },
                 },
             }),
@@ -409,13 +415,15 @@ export class HeroRoller {
             return this;
         }
 
-        this.#addOperatorTerm(numDice > 0 ? "+" : "-");
+        if (this._formulaTerms.length > 0) {
+            this.#addOperatorTerm(numDice > 0 ? "+" : "-");
+        }
 
-        const absNumDice = Math.abs(numDice);
+        numDice = this._formulaTerms.length > 0 ? Math.abs(numDice) : numDice;
         this._formulaTerms.push(
             new Die({
                 faces: 6,
-                number: absNumDice,
+                number: numDice,
                 options: {
                     _hrQualifier:
                         HeroRoller.QUALIFIER.FULL_DIE_LESS_ONE_MIN_ONE,
@@ -424,7 +432,7 @@ export class HeroRoller {
                         ? undefined
                         : {
                               name: description,
-                              value: absNumDice,
+                              value: numDice,
                           },
                 },
             }),
@@ -438,12 +446,14 @@ export class HeroRoller {
             return this;
         }
 
-        this.#addOperatorTerm(value > 0 ? "+" : "-");
+        if (this._formulaTerms.length > 0) {
+            this.#addOperatorTerm(value > 0 ? "+" : "-");
+        }
 
-        const absValue = Math.abs(value);
+        value = this._formulaTerms.length > 0 ? Math.abs(value) : value;
         this._formulaTerms.push(
             new NumericTerm({
-                number: absValue,
+                number: value,
                 options: {
                     _hrQualifier: HeroRoller.QUALIFIER.NUMBER,
                     flavor: description,
@@ -451,7 +461,7 @@ export class HeroRoller {
                         ? undefined
                         : {
                               name: description,
-                              value: absValue,
+                              value: value,
                           },
                 },
             }),
@@ -1225,7 +1235,7 @@ export class HeroRoller {
         const _calculatedTermsMetadata = [];
         const _calculatedTerms = [];
 
-        let lastOperatorMultiplier = 1; // Start with +1
+        let lastOperatorMultiplier = 1; // Start with +
 
         const _baseTermsMetadata = [];
         const _baseTerms = this._rollObj.terms

--- a/module/utility/dice.mjs
+++ b/module/utility/dice.mjs
@@ -36,10 +36,16 @@ const DICE_SO_NICE_CUSTOM_SETS = {
 
 const DICE_SO_NICE_CATEGORY_NAME = "Hero System 6e (Unofficial) V2";
 
-// v11/v12 compatibility shim
+// v11/v12 compatibility shim.
+// TODO: Cleanup eslint file with these terms
 const Die = CONFIG.Dice.terms.d;
 const NumericTerm = CONFIG.Dice.termTypes.NumericTerm;
 const OperatorTerm = CONFIG.Dice.termTypes.OperatorTerm;
+
+// foundry.dice.terms.RollTerm is the v12 way of finding the class
+const RollTermClass = foundry.dice?.terms.RollTerm
+    ? foundry.dice.terms.RollTerm
+    : RollTerm;
 
 /**
  * Add colour sets into Dice So Nice! This allows users to see what the colour set is for each function.
@@ -478,9 +484,16 @@ export class HeroRoller {
             this._options,
         );
 
+        // V12 doesn't have async as an option anymore - it is the default.
+        const evaluateOptions = foundry.utils.isNewerVersion(
+            game.version,
+            "11.315",
+        )
+            ? {}
+            : { async: true };
         await this._rollObj.evaluate({
             ...options,
-            async: true,
+            ...evaluateOptions,
         });
 
         await this.#calculateResults();
@@ -913,7 +926,7 @@ export class HeroRoller {
             ? Roll.fromData(dataObj._rollObj)
             : undefined;
         heroRoller._formulaTerms = dataObj._formulaTerms.map((_term, index) =>
-            RollTerm.fromData(dataObj._formulaTerms[index]),
+            RollTermClass.fromData(dataObj._formulaTerms[index]),
         );
 
         heroRoller._type = dataObj._type;
@@ -992,7 +1005,14 @@ export class HeroRoller {
                 )
                 .addHalfDice(this._killingStunMultiplier === "1d3" ? 1 : 0);
 
-            await this._killingStunMultiplierHeroRoller.roll({ async: true });
+            // V12 doesn't have async as an option anymore - it is the default.
+            const evaluateOptions = foundry.utils.isNewerVersion(
+                game.version,
+                "11.315",
+            )
+                ? {}
+                : { async: true };
+            await this._killingStunMultiplierHeroRoller.roll(evaluateOptions);
 
             this._killingBaseStunMultiplier =
                 this._killingStunMultiplierHeroRoller.getBasicTotal();


### PR DESCRIPTION
- fix deprecation warnings for dice related things
- v12 does not support starting with an `OperatorTerm`. Fortunately v11 can handle not starting with one as well so change to that behaviour.