### PR TITLE
fix(range penalty): correct range penalty calculations for non AoE attacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Version 3.0.78 (So far...) [Hero System 6e (Unofficial) v2](https://github.com/dmdorman/hero6e-foundryvtt)
+
+- Correct range penalty calculation for 5e non AoE attacks. [#1077](https://github.com/dmdorman/hero6e-foundryvtt/issues/1077)
+
 ## Version 3.0.77 [Hero System 6e (Unofficial) v2](https://github.com/dmdorman/hero6e-foundryvtt)
 
 - PD/ED characteristics with resistant modifier are now actually resistant.  Previously the resistant modifier was ignored.  Also PD/ED purchased as characteristics now show in DEFENSES tab for easy reference. [#1063](https://github.com/dmdorman/hero6e-foundryvtt/issues/1063)

--- a/module/item/item-attack.mjs
+++ b/module/item/item-attack.mjs
@@ -212,7 +212,7 @@ export async function AttackAoeToHit(item, options) {
             normalRange
         )
     ) {
-        let rangePenalty =
+        const rangePenalty =
             -calculateRangePenaltyFromDistanceInMetres(distanceToken);
 
         // PENALTY_SKILL_LEVELS (range)
@@ -401,15 +401,14 @@ export async function AttackToHit(item, options) {
             );
         }
 
-        let target = game.user.targets.first();
-        let distance = token
+        const target = game.user.targets.first();
+        const distance = token
             ? canvas.grid.measureDistance(token, target, {
                   gridSpaces: true,
               })
             : 0;
-        let factor = actor.system.is5e ? 4 : 8;
-        let rangePenalty = -Math.ceil(Math.log2(distance / factor)) * 2;
-        rangePenalty = rangePenalty > 0 ? 0 : rangePenalty;
+        const rangePenalty =
+            calculateRangePenaltyFromDistanceInMetres(distance);
 
         // PENALTY_SKILL_LEVELS (range)
         const pslRange = actor.items.find(


### PR DESCRIPTION
Likely only corrects 5e. Resolves #1077.