### PR TITLE
Make OCV/DCV consistent with OMCV/DMCV on attacks tab

### DIFF
--- a/module/actor/actor-sheet.mjs
+++ b/module/actor/actor-sheet.mjs
@@ -199,6 +199,7 @@ export class HeroSystemActorSheet extends ActorSheet {
 
                     // Signed OCV and DCV
                     if (item.system.ocv != undefined && item.system.uses === "ocv") {
+                        const ocv = parseInt(item.actor?.system.characteristics.ocv?.value || 0);
                         switch (item.system.ocv) {
                             case "--":
                                 item.system.ocvEstimated = "";
@@ -213,7 +214,7 @@ export class HeroSystemActorSheet extends ActorSheet {
                                     const velocity = calculateVelocityInSystemUnits(item.actor, token);
 
                                     item.system.ocvEstimated = (
-                                        parseInt(cslSummary.ocv) + parseInt(velocity / 10)
+                                        ocv + parseInt(cslSummary.ocv) + parseInt(velocity / 10)
                                     ).signedString();
 
                                     if (parseInt(velocity / 10) != 0) {
@@ -232,7 +233,7 @@ export class HeroSystemActorSheet extends ActorSheet {
                             default:
                                 item.system.ocv = parseInt(item.system.ocv).signedString();
                                 item.system.ocvEstimated = (
-                                    parseInt(item.system.ocv) + parseInt(cslSummary.ocv || cslSummary.omcv || 0)
+                                    ocv + parseInt(item.system.ocv) + parseInt(cslSummary.ocv || cslSummary.omcv || 0)
                                 ).signedString();
 
                                 if (parseInt(item.system.ocv) != 0) {
@@ -247,9 +248,10 @@ export class HeroSystemActorSheet extends ActorSheet {
                     }
 
                     if (item.system.dcv != undefined && item.system.uses === "ocv") {
+                        const dcv = parseInt(item.actor?.system.characteristics.dcv?.value || 0);
                         item.system.dcv = parseInt(item.system.dcv).signedString();
                         item.system.dcvEstimated = (
-                            parseInt(item.system.dcv) + parseInt(cslSummary.dcv || cslSummary.dmcv || 0)
+                            dcv + parseInt(item.system.dcv) + parseInt(cslSummary.dcv || cslSummary.dmcv || 0)
                         ).signedString();
 
                         if (parseInt(item.system.dcv) != 0) {

--- a/module/actor/actor-sheet.mjs
+++ b/module/actor/actor-sheet.mjs
@@ -214,7 +214,9 @@ export class HeroSystemActorSheet extends ActorSheet {
                                     const velocity = calculateVelocityInSystemUnits(item.actor, token);
 
                                     item.system.ocvEstimated = (
-                                        ocv + parseInt(cslSummary.ocv) + parseInt(velocity / 10)
+                                        ocv +
+                                        parseInt(cslSummary.ocv) +
+                                        parseInt(velocity / 10)
                                     ).signedString();
 
                                     if (parseInt(velocity / 10) != 0) {
@@ -233,7 +235,9 @@ export class HeroSystemActorSheet extends ActorSheet {
                             default:
                                 item.system.ocv = parseInt(item.system.ocv).signedString();
                                 item.system.ocvEstimated = (
-                                    ocv + parseInt(item.system.ocv) + parseInt(cslSummary.ocv || cslSummary.omcv || 0)
+                                    ocv +
+                                    parseInt(item.system.ocv) +
+                                    parseInt(cslSummary.ocv || cslSummary.omcv || 0)
                                 ).signedString();
 
                                 if (parseInt(item.system.ocv) != 0) {
@@ -251,7 +255,9 @@ export class HeroSystemActorSheet extends ActorSheet {
                         const dcv = parseInt(item.actor?.system.characteristics.dcv?.value || 0);
                         item.system.dcv = parseInt(item.system.dcv).signedString();
                         item.system.dcvEstimated = (
-                            dcv + parseInt(item.system.dcv) + parseInt(cslSummary.dcv || cslSummary.dmcv || 0)
+                            dcv +
+                            parseInt(item.system.dcv) +
+                            parseInt(cslSummary.dcv || cslSummary.dmcv || 0)
                         ).signedString();
 
                         if (parseInt(item.system.dcv) != 0) {


### PR DESCRIPTION
On the attacks tab, the OCV & DCV columns treat OCV/DCV differently from OMCV/DMCV. 

Currently, in the case of a standard OCV/DCV attack, the character's base OCV/DCV are not included in the calculation. While in the case of a mental attack, the base OMCV/DMCV _are_ included.

This screenshot shows the discrepancy. A character with base characteristics should show +3 for everything:
![ocv-dcv-missing](https://github.com/user-attachments/assets/2dd84940-5365-4a4a-8ba0-3f25efd1b91f)

This change makes the behavior consistent.

To consider: Should the column headers say OCV & DCV, or should they say something more generic like OV / DV?