### PR TITLE
Saturday night changes 24 08 2024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,34 @@
 # Releases
 
 ## Version 3.0.90 So far... [Hero System 6e (Unofficial) v2](https://github.com/dmdorman/hero6e-foundryvtt)
+
 - Added NOTES to item descriptions [#1140](https://github.com/dmdorman/hero6e-foundryvtt/issues/1140)
 - Initial support for Enhanced Perception [#1157](https://github.com/dmdorman/hero6e-foundryvtt/issues/1157)
-- Fixed missing EXTRADC calculations from Martial Maneuvers. [#1080](https://github.com/dmdorman/hero6e-foundryvtt/issues/1080)
-- Added system setting to limit damage, to double the base damage. [#1080](https://github.com/dmdorman/hero6e-foundryvtt/issues/1080)
-- Fixed inconsistancies with OCV/DCV values on Attack tab.
+- Fixed missing EXTRADC calculations from Martial Maneuvers and 5e killing attack maneuver DCs. [#1080](https://github.com/dmdorman/hero6e-foundryvtt/issues/1080)
+- Added system setting to limit total attack DCs to double the base DCs. This defaults to off! [#1080](https://github.com/dmdorman/hero6e-foundryvtt/issues/1080)
+- Fixed inconsistencies with OCV/DCV values on Attack tab.
 - Fixed ability to edit Mind Scan attack adjustments. [#1161](https://github.com/dmdorman/hero6e-foundryvtt/issues/1161)
 
 ## Version 3.0.89
+
 - Improved Analyze skill description. [#1154](https://github.com/dmdorman/hero6e-foundryvtt/issues/1150)
-- New Dice Skinning feature: Dice associated with hit locations, stun multipliers, and knockback have a different dice skin. Requires Dice So Nice module. Defaults to off, can be enabled per user. 
+- New Dice Skinning feature: Dice associated with hit locations, stun multipliers, and knockback have a different dice skin. Requires Dice So Nice module. Defaults to off, can be enabled per user.
 
 ## Version 3.0.88
+
 - Fix: When 2+ GMs are active, those GMs see errors when adding combatants to combat tracker [#1150](https://github.com/dmdorman/hero6e-foundryvtt/issues/1150)
 - Added FULL and CASUAL rolls for base characteristics to CHARACTERISTICS tab.
 - Improved Weapon Master [#1151](https://github.com/dmdorman/hero6e-foundryvtt/issues/1151)
 - Improved Requires A Roll for Knowledge Skills
 
 ## Version 3.0.87
+
 - Reworked ruler code.  Movement type & total distance only show for last movement segment. 
 - DragRuler support for v12. There are still [issues](https://github.com/manuelVo/foundryvtt-drag-ruler/issues/337), so not recommending upgrading to FoundryVTT v12 quite yet.
 - Fix: Players see errors when adding combatants to combat tracker [#1148](https://github.com/dmdorman/hero6e-foundryvtt/issues/1148)
 
 ## Version 3.0.86
+
 - Improve Foundry v12 support
 
 ## Version 3.0.85

--- a/lang/en.json
+++ b/lang/en.json
@@ -173,7 +173,7 @@
         },
         "StrEnd" : {
             "Name": "Heroic Strength & Endurance",
-            "Hint": "Using STR typipcally costs 1 END per 10 points of STR used.  In heroic campaigns the GM has the option of charging 1 END per 5 STR used.  This setting is ignored for Superheroic characters which will always use 1 END per 10 points of STR.  Heroic vs Superheroic is determined during HDC upload and is based on the Hero Designer template used.",
+            "Hint": "Using STR typipcally costs 1 END per 10 points of STR used. In heroic campaigns the GM has the option of charging 1 END per 5 STR used. This setting is ignored for Superheroic characters which will always use 1 END per 10 points of STR.  Heroic vs Superheroic is determined during HDC upload and is based on the Hero Designer template used.",
             "Choices": {
                 "five": "1 END per 5 STR",
                 "ten": "1 END per 10 STR"
@@ -187,7 +187,7 @@
         },
         "HAP": {
             "Name": "Heroic Action Points",
-            "Hint": "Optional 6e Rule, where each character rolls 2d6 to gain HAPs for that session.  Characters may spend HAPs for a variety of GM approved actions, typically to improve a failed dice roll."
+            "Hint": "Optional 6e Rule, where each character rolls 2d6 to gain HAPs for that session. Characters may spend HAPs for a variety of GM approved actions, typically to improve a failed dice roll."
         },
         "HexTemplates": {
             "Name": "Use hexagonal AOE templates",
@@ -220,17 +220,17 @@
         "LongTermEndurance": 
         {
             "Name": "Long-term Endurance",
-            "Hint": "Automate tracking of optional long-term endurance use. Currently a partial implementation.  When an actor's average END use per turn exceeds double their REC, max END is lowered."
+            "Hint": "Automate tracking of optional long-term endurance use. Currently a partial implementation. When an actor's average END use per turn exceeds double their REC, max END is lowered."
         },
         "DoubleDamageLimit": 
         {
             "Name": "Double Damage Limit",
-            "Hint": "A character cannot more than double the Damage Classes of his base attack, no matter how many different methods he uses to add damage. This should be enabled for 5E games. It is an optional rule for 6E games."
+            "Hint": "A character cannot more than double the Damage Classes of his base attack. This should be enabled for 5E games. It is an optional rule for 6E games."
         },
         "DiceSkinning": 
         {
             "Name": "Dice Skinning (Dice So Nice)",
-            "Hint": "Requires Dice So Nice module.  Dice associated with hit locations, stun multipliers, and knockback have a different dice skin."
+            "Hint": "Requires Dice So Nice module. Dice associated with hit locations, stun multipliers, and knockback have a different dice skin."
         },
         "UseKnockback": 
         {

--- a/module/item/item-attack.mjs
+++ b/module/item/item-attack.mjs
@@ -287,8 +287,9 @@ export async function AttackToHit(item, options) {
         options.effectiveLevels = parseInt(options.effectiveLevels) || 0;
         if (options.effectiveLevels > 0 && options.effectiveLevels !== parseInt(item.system.LEVELS)) {
             const effectiveItemData = item.toObject();
+            effectiveItemData._id = null;
             effectiveItemData.system.LEVELS = options.effectiveLevels;
-            effectiveItem = await HeroSystem6eItem.create(effectiveItemData, { temporary: true });
+            effectiveItem = await HeroSystem6eItem.create(effectiveItemData, { parent: item.actor, temporary: true });
             await effectiveItem._postUpload();
         }
     }
@@ -1308,8 +1309,9 @@ export async function _onRollDamage(event) {
         toHitData.effectiveLevels = parseInt(toHitData.effectiveLevels) || 0;
         if (toHitData.effectiveLevels > 0 && toHitData.effectiveLevels !== parseInt(item.system.LEVELS)) {
             const effectiveItemData = item.toObject();
+            effectiveItemData._id = null;
             effectiveItemData.system.LEVELS = toHitData.effectiveLevels;
-            effectiveItem = await HeroSystem6eItem.create(effectiveItemData, { temporary: true });
+            effectiveItem = await HeroSystem6eItem.create(effectiveItemData, { parent: item.actor, temporary: true });
             await effectiveItem._postUpload();
         }
     }
@@ -1548,8 +1550,9 @@ export async function _onRollMindScanEffectRoll(event) {
         toHitData.effectiveLevels = parseInt(toHitData.effectiveLevels) || 0;
         if (toHitData.effectiveLevels > 0 && toHitData.effectiveLevels !== parseInt(item.system.LEVELS)) {
             const effectiveItemData = item.toObject();
+            effectiveItemData._id = null;
             effectiveItemData.system.LEVELS = toHitData.effectiveLevels;
-            effectiveItem = await HeroSystem6eItem.create(effectiveItemData, { temporary: true });
+            effectiveItem = await HeroSystem6eItem.create(effectiveItemData, { parent: item.actor, temporary: true });
             await effectiveItem._postUpload();
         }
     }

--- a/module/item/item.mjs
+++ b/module/item/item.mjs
@@ -3817,8 +3817,9 @@ export class HeroSystem6eItem extends Item {
         this.name = name;
 
         // 5E extraDCLevels are halved for killing attacks
+        // TODO: FIXME: THis needs to be fixed properly as it doesn't actually subtract the DC.
         let dc = parseInt(this.system.DC);
-        if (this.system.is5e && this.system.killing && manuever) {
+        if (this.is5e && this.system.killing && ["maneuver", "martialart"].includes(this.type)) {
             dc = Math.floor(dc / 2);
         }
 

--- a/module/item/item.mjs
+++ b/module/item/item.mjs
@@ -3816,7 +3816,13 @@ export class HeroSystem6eItem extends Item {
         let name = this.system.NAME || description || this.system.name || this.name;
         this.name = name;
 
-        let levels = parseInt(this.system.value) || parseInt(this.system.DC) || 0;
+        // 5E extraDCLevels are halved for killing attacks
+        let dc = parseInt(this.system.DC);
+        if (this.system.is5e && this.system.killing && manuever) {
+            dc = Math.floor(dc / 2);
+        }
+
+        let levels = parseInt(this.system.value) || dc || 0;
         const input = this.system.INPUT;
 
         const ocv = parseInt(this.system.OCV) || 0;
@@ -4380,7 +4386,7 @@ export class HeroSystem6eItem extends Item {
                     : 0;
             const characteristicAdjustment = Math.round(characteristicValue / 5);
             const levelsAdjustment = parseInt(skillData.LEVELS?.value || skillData.LEVELS || skillData.levels) || 0;
-            var rollVal = baseRollValue + characteristicAdjustment + levelsAdjustment;
+            let rollVal = baseRollValue + characteristicAdjustment + levelsAdjustment;
 
             // Provide up to 3 tags to explain how the roll was calculated:
             // 1. Base skill value without modifier due to characteristics

--- a/module/item/item.mjs
+++ b/module/item/item.mjs
@@ -1126,7 +1126,7 @@ export class HeroSystem6eItem extends Item {
             item.system.active = !itemEffects.disabled;
         }
 
-        const actorEffects = item.actor.effects.find((o) => o.origin === this.actor.items.get(item._id).uuid);
+        const actorEffects = item.actor.effects.find((o) => o.origin === item.actor.items.get(item._id).uuid);
         {
             if (actorEffects) {
                 item.system.showToggle = true;

--- a/module/utility/damage.mjs
+++ b/module/utility/damage.mjs
@@ -33,9 +33,6 @@ export function convertToDiceParts(value) {
 
 // Determine DC solely from item/attack
 export function convertToDcFromItem(item, options) {
-    if (item.system.ALIAS === "Martial Strike") {
-        console.log(item);
-    }
     let actor = item.actor;
     let dc = 0;
     let tags = [];

--- a/module/utility/damage.mjs
+++ b/module/utility/damage.mjs
@@ -330,10 +330,11 @@ export function convertToDcFromItem(item, options) {
     // double the Damage Classes of his base attack, no
     // matter how many different methods he uses to add
     // damage.
+
     const DoubleDamageLimit = game.settings.get(HEROSYS.module, "DoubleDamageLimit");
     if (DoubleDamageLimit) {
         // BaseDC
-        var baseDC = baseDcParts.str;
+        let baseDC = baseDcParts.str;
         if (["HA", "KHA"].includes(item.system.XMLID) || item.system.CATEGORY === "Hand To Hand") {
             baseDC = baseDcParts.item;
         }
@@ -341,7 +342,8 @@ export function convertToDcFromItem(item, options) {
             baseDC += extraDcLevels;
         }
 
-        if (dc > baseDC * 2) {
+        // NOTE: baseDC > 0 is not great - need to consider things with effect rolls like mind scan and illusions
+        if (baseDC > 0 && dc > baseDC * 2) {
             const backOutDc = Math.floor(baseDC * 2 - dc);
             tags.push({
                 value: `${backOutDc}DC`,


### PR DESCRIPTION
- Cleanup changelog
- halve killing attack for manuevers in 5e (still broken)
- mind scan shouldn't get double clamped when there are no additional DCs added