### PR TITLE
Stun for end fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix: DRAIN has a standard range in 6e.
 - Fix: Partial STR dice is now added to damage. [#1193](https://github.com/dmdorman/hero6e-foundryvtt/issues/1193)
 - Fixed TRANSFORM to import properly, allowing for proper attack & damage rolls and END cost.
+- Fix STUN for END calculation especially when starting with negative END. [#1202](https://github.com/dmdorman/hero6e-foundryvtt/issues/1202)
 
 ## Version 3.0.92 [Hero System 6e (Unofficial) v2](https://github.com/dmdorman/hero6e-foundryvtt)
 

--- a/module/item/item-attack.mjs
+++ b/module/item/item-attack.mjs
@@ -555,6 +555,7 @@ export async function AttackToHit(item, options) {
             newEnd -= spentEnd;
         }
 
+        let stunDamageForEnd = 0;
         if (newEnd < 0) {
             // 1d6 STUN for each 2 END spent beyond 0 END- always round END use up to the nearest larger 2 END
             const endSpentAboveZero = Math.max(valueEnd, 0);
@@ -574,12 +575,9 @@ export async function AttackToHit(item, options) {
             const stunForEndHeroRoller = new HeroRoller().makeBasicRoll().addDice(stunDice);
             await stunForEndHeroRoller.roll();
             const stunRenderedResult = await stunForEndHeroRoller.render();
-            const stunDamageTotal = stunForEndHeroRoller.getBasicTotal();
+            stunDamageForEnd = stunForEndHeroRoller.getBasicTotal();
 
-            // NOTE: Gross. Shouldn't be using newEnd to hold stun total
-            newEnd = -stunDamageTotal;
-
-            enduranceText = `Spent ${valueEnd} END and ${stunDamageTotal} STUN`;
+            enduranceText = `Spent ${endSpentAboveZero} END and ${stunDamageForEnd} STUN`;
 
             enduranceText +=
                 ` <i class="fal fa-circle-info" data-tooltip="` +
@@ -616,7 +614,7 @@ export async function AttackToHit(item, options) {
                 changes = {
                     "system.characteristics.end.value": Math.min(valueEnd, 0),
                     "system.characteristics.stun.value":
-                        parseInt(actor.system.characteristics.stun.value) + parseInt(newEnd),
+                        parseInt(actor.system.characteristics.stun.value) - stunDamageForEnd,
                 };
             } else {
                 changes = {


### PR DESCRIPTION
Resolve #1202 by:
* fixing resetting END to 0, when starting END is negative, when STUN is spent
* cleaning some variable usage to make purpose clear
* correcting description of what was spent (END and STUN)
* correcting how much END below 0 was consumed to determine how much STUN should be used