### PR TITLE
Remove plusses from CV displays on actor sheet (and fix Haymaker CV typo)

### DIFF
--- a/module/item/item.mjs
+++ b/module/item/item.mjs
@@ -1240,11 +1240,7 @@ export class HeroSystem6eItem extends Item {
                             const token = tokens[0];
                             const velocity = calculateVelocityInSystemUnits(item.actor, token);
 
-                            item.system.ocvEstimated = (
-                                ocv +
-                                parseInt(cslSummary.ocv) +
-                                parseInt(velocity / 10)
-                            ).signedString();
+                            item.system.ocvEstimated = String(ocv + parseInt(cslSummary.ocv) + parseInt(velocity / 10));
 
                             if (parseInt(velocity / 10) != 0) {
                                 if (item.flags.tag.ocv) {
@@ -1262,11 +1258,9 @@ export class HeroSystem6eItem extends Item {
                     default:
                         item.system.ocv = parseInt(item.system.ocv).signedString();
 
-                        item.system.ocvEstimated = (
-                            ocv +
-                            parseInt(item.system.ocv) +
-                            parseInt(cslSummary.ocv || cslSummary.omcv || 0)
-                        ).signedString();
+                        item.system.ocvEstimated = String(
+                            ocv + parseInt(item.system.ocv) + parseInt(cslSummary.ocv || cslSummary.omcv || 0),
+                        );
 
                         if (parseInt(item.system.ocv) != 0) {
                             if (item.flags.tags.ocv) {
@@ -1290,11 +1284,9 @@ export class HeroSystem6eItem extends Item {
                     item.flags.tags.dcv = `${item.flags.tags.dcv}${dcv.signedString()} DCV`;
                 }
                 item.system.dcv = parseInt(item.system.dcv).signedString();
-                item.system.dcvEstimated = (
-                    dcv +
-                    parseInt(item.system.dcv) +
-                    parseInt(cslSummary.dcv || cslSummary.dmcv || 0)
-                ).signedString();
+                item.system.dcvEstimated = String(
+                    dcv + parseInt(item.system.dcv) + parseInt(cslSummary.dcv || cslSummary.dmcv || 0),
+                );
 
                 if (parseInt(item.system.dcv) != 0) {
                     if (item.flags.tags.dcv) {
@@ -1308,7 +1300,7 @@ export class HeroSystem6eItem extends Item {
 
             if (item.system.uses === "omcv") {
                 const omcv = parseInt(item.actor?.system.characteristics.omcv?.value || 0);
-                item.system.ocvEstimated = (omcv + parseInt(cslSummary.omcv || 0)).signedString();
+                item.system.ocvEstimated = String(omcv + parseInt(cslSummary.omcv || 0));
                 if (omcv != 0) {
                     if (item.flags.tags.omcv) {
                         item.flags.tags.omcv += "\n";
@@ -1319,7 +1311,7 @@ export class HeroSystem6eItem extends Item {
                 }
 
                 const dmcv = parseInt(item.actor?.system.characteristics.dmcv?.value || 0);
-                item.system.dcvEstimated = (dmcv + parseInt(cslSummary.dmcv || 0)).signedString();
+                item.system.dcvEstimated = String(dmcv + parseInt(cslSummary.dmcv || 0));
                 if (dmcv != 0) {
                     if (item.flags.tags.dmcv) {
                         item.flags.tags.dmcv += "\n";
@@ -1335,7 +1327,7 @@ export class HeroSystem6eItem extends Item {
                 (o) => o.type == "maneuver" && o.name === "Set" && o.system.active,
             );
             if (setManeuver) {
-                item.system.ocvEstimated = (parseInt(item.system.ocvEstimated) + 1).signedString();
+                item.system.ocvEstimated = String(parseInt(item.system.ocvEstimated) + 1);
 
                 if (item.flags.tags.ocv) {
                     item.flags.tags.ocv += "\n";
@@ -1350,14 +1342,14 @@ export class HeroSystem6eItem extends Item {
                 (o) => o.type == "maneuver" && o.name === "Haymaker" && o.system.active,
             );
             if (haymakerManeuver) {
-                item.system.dcvEstimated = (parseInt(item.system.dcvEstimated) - 4).signedString();
+                item.system.dcvEstimated = String(parseInt(item.system.dcvEstimated) - 5);
 
                 if (item.flags.tags.dcv) {
                     item.flags.tags.dcv += "\n";
                 } else {
                     item.flags.tags.dcv = "";
                 }
-                item.flags.tags.dcv += `-4 Haymaker`;
+                item.flags.tags.dcv += `-5 Haymaker`;
             }
 
             item.system.phase = item.system.PHASE;

--- a/module/item/item.mjs
+++ b/module/item/item.mjs
@@ -1240,7 +1240,7 @@ export class HeroSystem6eItem extends Item {
                             const token = tokens[0];
                             const velocity = calculateVelocityInSystemUnits(item.actor, token);
 
-                            item.system.ocvEstimated = String(ocv + parseInt(cslSummary.ocv) + parseInt(velocity / 10));
+                            item.system.ocvEstimated = `${ocv + parseInt(cslSummary.ocv) + parseInt(velocity / 10)}`;
 
                             if (parseInt(velocity / 10) != 0) {
                                 if (item.flags.tag.ocv) {
@@ -1258,9 +1258,7 @@ export class HeroSystem6eItem extends Item {
                     default:
                         item.system.ocv = parseInt(item.system.ocv).signedString();
 
-                        item.system.ocvEstimated = String(
-                            ocv + parseInt(item.system.ocv) + parseInt(cslSummary.ocv || cslSummary.omcv || 0),
-                        );
+                        item.system.ocvEstimated = `${ocv + parseInt(item.system.ocv) + parseInt(cslSummary.ocv || cslSummary.omcv || 0)}`;
 
                         if (parseInt(item.system.ocv) != 0) {
                             if (item.flags.tags.ocv) {
@@ -1284,9 +1282,7 @@ export class HeroSystem6eItem extends Item {
                     item.flags.tags.dcv = `${item.flags.tags.dcv}${dcv.signedString()} DCV`;
                 }
                 item.system.dcv = parseInt(item.system.dcv).signedString();
-                item.system.dcvEstimated = String(
-                    dcv + parseInt(item.system.dcv) + parseInt(cslSummary.dcv || cslSummary.dmcv || 0),
-                );
+                item.system.dcvEstimated = `${dcv + parseInt(item.system.dcv) + parseInt(cslSummary.dcv || cslSummary.dmcv || 0)}`;
 
                 if (parseInt(item.system.dcv) != 0) {
                     if (item.flags.tags.dcv) {
@@ -1300,7 +1296,7 @@ export class HeroSystem6eItem extends Item {
 
             if (item.system.uses === "omcv") {
                 const omcv = parseInt(item.actor?.system.characteristics.omcv?.value || 0);
-                item.system.ocvEstimated = String(omcv + parseInt(cslSummary.omcv || 0));
+                item.system.ocvEstimated = `${omcv + parseInt(cslSummary.omcv || 0)}`;
                 if (omcv != 0) {
                     if (item.flags.tags.omcv) {
                         item.flags.tags.omcv += "\n";
@@ -1311,7 +1307,7 @@ export class HeroSystem6eItem extends Item {
                 }
 
                 const dmcv = parseInt(item.actor?.system.characteristics.dmcv?.value || 0);
-                item.system.dcvEstimated = String(dmcv + parseInt(cslSummary.dmcv || 0));
+                item.system.dcvEstimated = `${dmcv + parseInt(cslSummary.dmcv || 0)}`;
                 if (dmcv != 0) {
                     if (item.flags.tags.dmcv) {
                         item.flags.tags.dmcv += "\n";
@@ -1327,7 +1323,7 @@ export class HeroSystem6eItem extends Item {
                 (o) => o.type == "maneuver" && o.name === "Set" && o.system.active,
             );
             if (setManeuver) {
-                item.system.ocvEstimated = String(parseInt(item.system.ocvEstimated) + 1);
+                item.system.ocvEstimated = `${parseInt(item.system.ocvEstimated) + 1}`;
 
                 if (item.flags.tags.ocv) {
                     item.flags.tags.ocv += "\n";
@@ -1342,7 +1338,7 @@ export class HeroSystem6eItem extends Item {
                 (o) => o.type == "maneuver" && o.name === "Haymaker" && o.system.active,
             );
             if (haymakerManeuver) {
-                item.system.dcvEstimated = String(parseInt(item.system.dcvEstimated) - 5);
+                item.system.dcvEstimated = `${parseInt(item.system.dcvEstimated) - 5}`;
 
                 if (item.flags.tags.dcv) {
                     item.flags.tags.dcv += "\n";

--- a/module/testing/testing-full.mjs
+++ b/module/testing/testing-full.mjs
@@ -1548,17 +1548,11 @@ export function registerFullTests(quench) {
                 });
 
                 it("Killing Strike OCV", async function () {
-                    assert.equal(
-                        actor.items.find((o) => o.system.ALIAS === "Killing Strike").system.ocvEstimated,
-                        "+1",
-                    );
+                    assert.equal(actor.items.find((o) => o.system.ALIAS === "Killing Strike").system.ocvEstimated, "1");
                 });
 
                 it("Killing Strike DCV", async function () {
-                    assert.equal(
-                        actor.items.find((o) => o.system.ALIAS === "Killing Strike").system.dcvEstimated,
-                        "+3",
-                    );
+                    assert.equal(actor.items.find((o) => o.system.ALIAS === "Killing Strike").system.dcvEstimated, "3");
                 });
 
                 it("Martial Strike damage", async function () {
@@ -1566,17 +1560,11 @@ export function registerFullTests(quench) {
                 });
 
                 it("Martial Strike OCV", async function () {
-                    assert.equal(
-                        actor.items.find((o) => o.system.ALIAS === "Martial Strike").system.ocvEstimated,
-                        "+3",
-                    );
+                    assert.equal(actor.items.find((o) => o.system.ALIAS === "Martial Strike").system.ocvEstimated, "3");
                 });
 
                 it("Martial Strike DCV", async function () {
-                    assert.equal(
-                        actor.items.find((o) => o.system.ALIAS === "Martial Strike").system.dcvEstimated,
-                        "+5",
-                    );
+                    assert.equal(actor.items.find((o) => o.system.ALIAS === "Martial Strike").system.dcvEstimated, "5");
                 });
 
                 it("HKA damage", async function () {


### PR DESCRIPTION
Removed the .signedString() calls on the ocvEstimated & dcvEstimated displays, to better reflect that these displayed values are calculated CVs rather than bonuses.

Also fixed a typo that changed the Haymaker CV penalty to -4 (it should be -5). This will be converted as maneuver XML parsing is implemented but in the meantime it's good to get this little fix in.

![Screenshot 2024-09-11 195919](https://github.com/user-attachments/assets/ab6cabd5-f27a-4c7e-bb17-65a9e403ffe4)
