### PR TITLE
Improve entangle description to support mental entangle

### DIFF
--- a/module/item/item.mjs
+++ b/module/item/item.mjs
@@ -2951,12 +2951,30 @@ export class HeroSystem6eItem extends Item {
 
             case "ENTANGLE":
                 {
-                    // Entangle 2d6, 7 PD/2 ED
-                    const pd_entangle =
-                        parseInt(system.value || 0) + parseInt(this.findModsByXmlid("ADDITIONALPD")?.LEVELS || 0);
-                    const ed_entangle =
-                        parseInt(system.value || 0) + parseInt(this.findModsByXmlid("ADDITIONALED")?.LEVELS || 0);
-                    system.description = `${system.ALIAS} ${system.value}d6, ${pd_entangle} PD/${ed_entangle} ED`;
+                    // Entangle 2d6, 7 rPD/2 rED or Entangle 2d6 5 rMD
+                    const baseDef = parseInt(system.value || 0);
+
+                    const additionalDef = parseInt(this.findModsByXmlid("ADDITIONALDEF")?.LEVELS || 0);
+                    const additionalPD = parseInt(this.findModsByXmlid("ADDITIONALPD")?.LEVELS || 0);
+                    const additionalED = parseInt(this.findModsByXmlid("ADDITIONALED")?.LEVELS || 0);
+
+                    const rPD = baseDef + additionalPD;
+                    const rED = baseDef + additionalED;
+                    // 6e +1 DEF = +2 rMD. NOTE: HD doesn't have ability to buy MD in 6e.
+                    const rMD = baseDef + 2 * (additionalDef || additionalPD + additionalED);
+
+                    // BOECV for 5e, ACV for 6e
+                    const mentalEntangle =
+                        (this.findModsByXmlid("BOECV") &&
+                            this.findModsByXmlid("TAKESNODAMAGE") &&
+                            this.findModsByXmlid("VERSUSEGO")) ||
+                        (this.findModsByXmlid("ACV") &&
+                            this.findModsByXmlid("TAKESNODAMAGE") &&
+                            this.findModsByXmlid("VERSUSEGO"));
+
+                    system.description = `${system.ALIAS} ${system.value}d6, ${
+                        mentalEntangle ? `${rMD} rMD` : `${rPD} rPD/${rED} rED`
+                    }`;
                 }
                 break;
 

--- a/module/testing/testing-upload.mjs
+++ b/module/testing/testing-upload.mjs
@@ -6517,6 +6517,245 @@ export function registerUploadTests(quench) {
                     assert.equal(item.system.roll, "20-"); // Perception (12-) + 8 levels = 20-
                 });
             });
+
+            describe("ENTANGLE", async function () {
+                describe("NORMAL ENTANGLE (5e)", async function () {
+                    const contents = `
+                        <POWER XMLID="ENTANGLE" ID="1726444317879" BASECOST="0.0" LEVELS="2" ALIAS="Entangle" POSITION="0" MULTIPLIER="1.0" GRAPHIC="Burst" COLOR="255 255 255" SFX="Default" SHOW_ACTIVE_COST="Yes" INCLUDE_NOTES_IN_PRINTOUT="Yes" NAME="" USESTANDARDEFFECT="No" QUANTITY="1" AFFECTS_PRIMARY="No" AFFECTS_TOTAL="Yes">
+                            <NOTES />
+                            <ADDER XMLID="ADDITIONALDEF" ID="1726444405997" BASECOST="0.0" LEVELS="2" ALIAS="+2 Additional DEF" POSITION="-1" MULTIPLIER="1.0" GRAPHIC="Burst" COLOR="255 255 255" SFX="Default" SHOW_ACTIVE_COST="Yes" INCLUDE_NOTES_IN_PRINTOUT="Yes" NAME="" SHOWALIAS="Yes" PRIVATE="No" REQUIRED="No" INCLUDEINBASE="No" DISPLAYINSTRING="No" GROUP="No" LVLCOST="5.0" LVLVAL="1.0" SELECTED="YES">
+                                <NOTES />
+                            </ADDER>
+                        </POWER>
+                    `;
+                    let item;
+
+                    before(async () => {
+                        const actor = new HeroSystem6eActor(
+                            {
+                                name: "Quench Actor",
+                                type: "pc",
+                            },
+                            { temporary: true },
+                        );
+                        actor.system.is5e = true;
+                        await actor._postUpload();
+
+                        item = await new HeroSystem6eItem(HeroSystem6eItem.itemDataFromXml(contents, actor), {
+                            temporary: true,
+                            parent: actor,
+                        });
+                        await item._postUpload();
+                        actor.items.set(item.system.XMLID, item);
+                    });
+
+                    it("description", function () {
+                        assert.equal(item.system.description, "Entangle 2d6, 2 rPD/2 rED (+2 Additional DEF)");
+                    });
+
+                    it("realCost", function () {
+                        assert.equal(item.system.realCost, 30);
+                    });
+
+                    it("activePoints", function () {
+                        assert.equal(item.system.activePoints, 30);
+                    });
+
+                    it("levels", function () {
+                        assert.equal(item.system.value, 2);
+                    });
+
+                    it("end", function () {
+                        assert.equal(item.system.end, 3);
+                    });
+                });
+
+                describe("MENTAL ENTANGLE (5e)", async function () {
+                    const contents = `
+                        <POWER XMLID="ENTANGLE" ID="1726444339547" BASECOST="0.0" LEVELS="2" ALIAS="Entangle" POSITION="1" MULTIPLIER="1.0" GRAPHIC="Burst" COLOR="255 255 255" SFX="Default" SHOW_ACTIVE_COST="Yes" INCLUDE_NOTES_IN_PRINTOUT="Yes" NAME="" USESTANDARDEFFECT="No" QUANTITY="1" AFFECTS_PRIMARY="No" AFFECTS_TOTAL="Yes">
+                            <NOTES />
+                            <ADDER XMLID="ADDITIONALDEF" ID="1726540002547" BASECOST="0.0" LEVELS="2" ALIAS="+2 Additional DEF" POSITION="-1" MULTIPLIER="1.0" GRAPHIC="Burst" COLOR="255 255 255" SFX="Default" SHOW_ACTIVE_COST="Yes" INCLUDE_NOTES_IN_PRINTOUT="Yes" NAME="" SHOWALIAS="Yes" PRIVATE="No" REQUIRED="No" INCLUDEINBASE="No" DISPLAYINSTRING="No" GROUP="No" LVLCOST="5.0" LVLVAL="1.0" SELECTED="YES">
+                                <NOTES />
+                            </ADDER>
+                            <MODIFIER XMLID="BOECV" ID="1726539977724" BASECOST="1.0" LEVELS="0" ALIAS="Based On EGO Combat Value" POSITION="-1" MULTIPLIER="1.0" GRAPHIC="Burst" COLOR="255 255 255" SFX="Default" SHOW_ACTIVE_COST="Yes" OPTION="MENTAL" OPTIONID="MENTAL" OPTION_ALIAS="Mental Defense applies" INCLUDE_NOTES_IN_PRINTOUT="Yes" NAME="" COMMENTS="" PRIVATE="No" FORCEALLOW="No">
+                                <NOTES />
+                            </MODIFIER>
+                            <MODIFIER XMLID="TAKESNODAMAGE" ID="1726539977730" BASECOST="0.25" LEVELS="0" ALIAS="Takes No Damage From Attacks" POSITION="-1" MULTIPLIER="1.0" GRAPHIC="Burst" COLOR="255 255 255" SFX="Default" SHOW_ACTIVE_COST="Yes" OPTION="LIMITED" OPTIONID="LIMITED" OPTION_ALIAS="Limited Group" INCLUDE_NOTES_IN_PRINTOUT="Yes" NAME="" COMMENTS="" PRIVATE="No" FORCEALLOW="No">
+                                <NOTES />
+                            </MODIFIER>
+                            <MODIFIER XMLID="NOBARRIERS" ID="1726539977732" BASECOST="-0.25" LEVELS="0" ALIAS="Cannot Form Barriers" POSITION="-1" MULTIPLIER="1.0" GRAPHIC="Burst" COLOR="255 255 255" SFX="Default" SHOW_ACTIVE_COST="Yes" INCLUDE_NOTES_IN_PRINTOUT="Yes" NAME="" COMMENTS="" PRIVATE="No" FORCEALLOW="No">
+                                <NOTES />
+                            </MODIFIER>
+                            <MODIFIER XMLID="VERSUSEGO" ID="1726539977733" BASECOST="0.25" LEVELS="0" ALIAS="Works Against EGO, Not STR" POSITION="-1" MULTIPLIER="1.0" GRAPHIC="Burst" COLOR="255 255 255" SFX="Default" SHOW_ACTIVE_COST="Yes" INCLUDE_NOTES_IN_PRINTOUT="Yes" NAME="" COMMENTS="" PRIVATE="No" FORCEALLOW="No">
+                                <NOTES />
+                            </MODIFIER>
+                        </POWER>
+                    `;
+                    let item;
+
+                    before(async () => {
+                        const actor = new HeroSystem6eActor(
+                            {
+                                name: "Quench Actor",
+                                type: "pc",
+                            },
+                            { temporary: true },
+                        );
+                        actor.system.is5e = true;
+                        await actor._postUpload();
+
+                        item = await new HeroSystem6eItem(HeroSystem6eItem.itemDataFromXml(contents, actor), {
+                            temporary: true,
+                            parent: actor,
+                        });
+                        await item._postUpload();
+                        actor.items.set(item.system.XMLID, item);
+                    });
+
+                    it("description", function () {
+                        assert.equal(
+                            item.system.description,
+                            "Entangle 2d6, 6 rMD (+2 Additional DEF), Takes No Damage From Attacks (Limited Group; +1/4), Works Against EGO, Not STR (+1/4), Based On EGO Combat Value (Mental Defense applies; +1) (75 Active Points); Cannot Form Barriers (-1/4)",
+                        );
+                    });
+
+                    it("realCost", function () {
+                        assert.equal(item.system.realCost, 60);
+                    });
+
+                    it("activePoints", function () {
+                        assert.equal(item.system.activePoints, 75);
+                    });
+
+                    it("levels", function () {
+                        assert.equal(item.system.value, 2);
+                    });
+
+                    it("end", function () {
+                        assert.equal(item.system.end, 7);
+                    });
+                });
+
+                describe("NORMAL ENTANGLE (6e)", async function () {
+                    const contents = `
+                        <POWER XMLID="ENTANGLE" ID="1726444520895" BASECOST="0.0" LEVELS="2" ALIAS="Entangle" POSITION="0" MULTIPLIER="1.0" GRAPHIC="Burst" COLOR="255 255 255" SFX="Default" SHOW_ACTIVE_COST="Yes" INCLUDE_NOTES_IN_PRINTOUT="Yes" NAME="" USESTANDARDEFFECT="No" QUANTITY="1" AFFECTS_PRIMARY="No" AFFECTS_TOTAL="Yes">
+                            <NOTES />
+                            <ADDER XMLID="ADDITIONALPD" ID="1726444611655" BASECOST="0.0" LEVELS="2" ALIAS="+2 Additional PD" POSITION="-1" MULTIPLIER="1.0" GRAPHIC="Burst" COLOR="255 255 255" SFX="Default" SHOW_ACTIVE_COST="Yes" INCLUDE_NOTES_IN_PRINTOUT="Yes" NAME="" SHOWALIAS="Yes" PRIVATE="No" REQUIRED="No" INCLUDEINBASE="No" DISPLAYINSTRING="No" GROUP="No" LVLCOST="5.0" LVLVAL="2.0" SELECTED="YES">
+                                <NOTES />
+                            </ADDER>
+                            <ADDER XMLID="ADDITIONALED" ID="1726444612388" BASECOST="0.0" LEVELS="2" ALIAS="+2 Additional ED" POSITION="-1" MULTIPLIER="1.0" GRAPHIC="Burst" COLOR="255 255 255" SFX="Default" SHOW_ACTIVE_COST="Yes" INCLUDE_NOTES_IN_PRINTOUT="Yes" NAME="" SHOWALIAS="Yes" PRIVATE="No" REQUIRED="No" INCLUDEINBASE="No" DISPLAYINSTRING="No" GROUP="No" LVLCOST="5.0" LVLVAL="2.0" SELECTED="YES">
+                                <NOTES />
+                            </ADDER>
+                        </POWER>
+                    `;
+                    let item;
+
+                    before(async () => {
+                        const actor = new HeroSystem6eActor(
+                            {
+                                name: "Quench Actor",
+                                type: "pc",
+                            },
+                            { temporary: true },
+                        );
+                        actor.system.is5e = false;
+                        await actor._postUpload();
+
+                        item = await new HeroSystem6eItem(HeroSystem6eItem.itemDataFromXml(contents, actor), {
+                            temporary: true,
+                            parent: actor,
+                        });
+                        await item._postUpload();
+                        actor.items.set(item.system.XMLID, item);
+                    });
+
+                    it("description", function () {
+                        assert.equal(item.system.description, "Entangle 2d6, 4 rPD/4 rED");
+                    });
+
+                    it("realCost", function () {
+                        assert.equal(item.system.realCost, 30);
+                    });
+
+                    it("activePoints", function () {
+                        assert.equal(item.system.activePoints, 30);
+                    });
+
+                    it("levels", function () {
+                        assert.equal(item.system.value, 2);
+                    });
+
+                    it("end", function () {
+                        assert.equal(item.system.end, 3);
+                    });
+                });
+
+                describe("MENTAL ENTANGLE (6e)", async function () {
+                    const contents = `
+                        <POWER XMLID="ENTANGLE" ID="1726444532291" BASECOST="0.0" LEVELS="2" ALIAS="Entangle" POSITION="1" MULTIPLIER="1.0" GRAPHIC="Burst" COLOR="255 255 255" SFX="Default" SHOW_ACTIVE_COST="Yes" INCLUDE_NOTES_IN_PRINTOUT="Yes" NAME="" USESTANDARDEFFECT="No" QUANTITY="1" AFFECTS_PRIMARY="No" AFFECTS_TOTAL="Yes">
+                            <NOTES />
+                            <ADDER XMLID="ADDITIONALED" ID="1726627613951" BASECOST="0.0" LEVELS="2" ALIAS="+2 Additional ED" POSITION="-1" MULTIPLIER="1.0" GRAPHIC="Burst" COLOR="255 255 255" SFX="Default" SHOW_ACTIVE_COST="Yes" INCLUDE_NOTES_IN_PRINTOUT="Yes" NAME="" SHOWALIAS="Yes" PRIVATE="No" REQUIRED="No" INCLUDEINBASE="No" DISPLAYINSTRING="No" GROUP="No" LVLCOST="5.0" LVLVAL="2.0" SELECTED="YES">
+                                <NOTES />
+                            </ADDER>
+                            <MODIFIER XMLID="ACV" ID="1726627613960" BASECOST="0.25" LEVELS="0" ALIAS="Alternate Combat Value" POSITION="-1" MULTIPLIER="1.0" GRAPHIC="Burst" COLOR="255 255 255" SFX="Default" SHOW_ACTIVE_COST="Yes" OPTION="NONMENTALOMCVDMCV" OPTIONID="NONMENTALOMCVDMCV" OPTION_ALIAS="uses OMCV against DMCV" INCLUDE_NOTES_IN_PRINTOUT="Yes" NAME="" COMMENTS="" PRIVATE="No" FORCEALLOW="No">
+                                <NOTES />
+                            </MODIFIER>
+                            <MODIFIER XMLID="TAKESNODAMAGE" ID="1726627613967" BASECOST="1.0" LEVELS="0" ALIAS="Takes No Damage From Attacks" POSITION="-1" MULTIPLIER="1.0" GRAPHIC="Burst" COLOR="255 255 255" SFX="Default" SHOW_ACTIVE_COST="Yes" OPTION="STRONLY" OPTIONID="STRONLY" OPTION_ALIAS="All Attacks, STR only to break out" INCLUDE_NOTES_IN_PRINTOUT="Yes" NAME="" COMMENTS="" PRIVATE="No" FORCEALLOW="No">
+                                <NOTES />
+                            </MODIFIER>
+                            <MODIFIER XMLID="VERSUSEGO" ID="1726627613969" BASECOST="0.25" LEVELS="0" ALIAS="Works Against EGO, Not STR" POSITION="-1" MULTIPLIER="1.0" GRAPHIC="Burst" COLOR="255 255 255" SFX="Default" SHOW_ACTIVE_COST="Yes" INCLUDE_NOTES_IN_PRINTOUT="Yes" NAME="" COMMENTS="" PRIVATE="No" FORCEALLOW="No">
+                                <NOTES />
+                            </MODIFIER>
+                            <MODIFIER XMLID="COSTSENDTOMAINTAIN" ID="1726627718650" BASECOST="-0.5" LEVELS="0" ALIAS="Costs END To Maintain" POSITION="-1" MULTIPLIER="1.0" GRAPHIC="Burst" COLOR="255 255 255" SFX="Default" SHOW_ACTIVE_COST="Yes" OPTION="FULL" OPTIONID="FULL" OPTION_ALIAS="Full END Cost" INCLUDE_NOTES_IN_PRINTOUT="Yes" NAME="" COMMENTS="" PRIVATE="No" FORCEALLOW="No">
+                                <NOTES />
+                            </MODIFIER>
+                        </POWER>
+                    `;
+                    let item;
+
+                    before(async () => {
+                        const actor = new HeroSystem6eActor(
+                            {
+                                name: "Quench Actor",
+                                type: "pc",
+                            },
+                            { temporary: true },
+                        );
+                        actor.system.is5e = false;
+                        await actor._postUpload();
+
+                        item = await new HeroSystem6eItem(HeroSystem6eItem.itemDataFromXml(contents, actor), {
+                            temporary: true,
+                            parent: actor,
+                        });
+                        await item._postUpload();
+                        actor.items.set(item.system.XMLID, item);
+                    });
+
+                    it("description", function () {
+                        assert.equal(
+                            item.system.description,
+                            "Entangle 2d6, 6 rMD, Alternate Combat Value (uses OMCV against DMCV; +1/4), Works Against EGO, Not STR (+1/4), Takes No Damage From Attacks (All Attacks, STR only to break out; +1) (62 Active Points); Costs END To Maintain (Full END Cost; -1/2)",
+                        );
+                    });
+
+                    it("realCost", function () {
+                        assert.equal(item.system.realCost, 41);
+                    });
+
+                    it("activePoints", function () {
+                        assert.equal(item.system.activePoints, 62);
+                    });
+
+                    it("levels", function () {
+                        assert.equal(item.system.value, 2);
+                    });
+
+                    it("end", function () {
+                        assert.equal(item.system.end, 6);
+                    });
+                });
+            });
         },
         { displayName: "HERO: Upload" },
     );


### PR DESCRIPTION
- add mental entangle support (note that HD doesn't support it correctly)
- add tests
- mark PD, ED, and MD as resistant
- 6e mental entangle is 2 rMD per additional level - assume that 5e is as well