### PR TITLE
Support different damage results for different targets (typically based on range)

### DIFF
--- a/module/handlebars-helpers.mjs
+++ b/module/handlebars-helpers.mjs
@@ -6,7 +6,9 @@ export function initializeHandlebarsHelpers() {
     Handlebars.registerHelper("gameConfigValue", gameConfigValue);
     Handlebars.registerHelper("getModulePath", getModulePath);
     Handlebars.registerHelper("includes", includes);
-    Handlebars.registerHelper("jsonify", jsonify);
+    Handlebars.registerHelper("toJSON", toJSON);
+    Handlebars.registerHelper("toArray", toArray);
+    Handlebars.registerHelper("toJsonArray", toJsonArray);
     Handlebars.registerHelper("increment", increment);
     Handlebars.registerHelper("indexOf", indexOf);
     Handlebars.registerHelper("is_active_segment", isActiveSegment);
@@ -40,8 +42,23 @@ function includes(str, searchTerm) {
     return str?.includes(searchTerm);
 }
 
-function jsonify(context) {
+function toJSON(context) {
     return JSON.stringify(context);
+}
+
+/**
+ * Takes args and turns it into an array.
+ *
+ * @returns Array
+ */
+function toArray(arg) {
+    if (arg == null) return [];
+
+    return [arg];
+}
+
+function toJsonArray(arg) {
+    return toJSON(toArray(arg));
 }
 
 function toLowerCase(str) {
@@ -57,12 +74,14 @@ function isActiveSegment(actives, index) {
 }
 
 function concat() {
-    var outStr = "";
-    for (var arg in arguments) {
-        if (typeof arguments[arg] != "object") {
+    let outStr = "";
+
+    for (const arg in arguments) {
+        if (typeof arguments[arg] !== "object") {
             outStr += arguments[arg];
         }
     }
+
     return outStr;
 }
 

--- a/module/handlebars-helpers.mjs
+++ b/module/handlebars-helpers.mjs
@@ -6,6 +6,7 @@ export function initializeHandlebarsHelpers() {
     Handlebars.registerHelper("gameConfigValue", gameConfigValue);
     Handlebars.registerHelper("getModulePath", getModulePath);
     Handlebars.registerHelper("includes", includes);
+    Handlebars.registerHelper("jsonify", jsonify);
     Handlebars.registerHelper("increment", increment);
     Handlebars.registerHelper("indexOf", indexOf);
     Handlebars.registerHelper("is_active_segment", isActiveSegment);
@@ -37,6 +38,10 @@ function getModulePath(templateDirectory) {
 
 function includes(str, searchTerm) {
     return str?.includes(searchTerm);
+}
+
+function jsonify(context) {
+    return JSON.stringify(context);
 }
 
 function toLowerCase(str) {

--- a/module/item/item-attack-application.mjs
+++ b/module/item/item-attack-application.mjs
@@ -254,7 +254,7 @@ export class ItemAttackFormApplication extends FormApplication {
             data.action = Attack.getActionInfo(
                 data.item,
                 data.targets,
-                data.formData, // use formdata to include player options from the form
+                data.formData, // use formData to include player options from the form
             );
             // the title seems to be fixed when the form is initialized,
             // and doesn't change afterwards even if we come through here again

--- a/module/item/item-attack.mjs
+++ b/module/item/item-attack.mjs
@@ -1199,7 +1199,7 @@ function getAttackTags(item) {
 
 export async function _onRollAoeDamage(event) {
     const button = event.currentTarget;
-    button.blur(); // The button remains highlighted for some reason; kluge to fix.
+    button.blur(); // The button remains highlighted for some reason; kludge to fix.
     const options = { ...button.dataset };
     const item = fromUuidSync(options.itemId);
     return AttackToHit(item, JSON.parse(options.formData));
@@ -1207,7 +1207,7 @@ export async function _onRollAoeDamage(event) {
 
 export async function _onRollKnockback(event) {
     const button = event.currentTarget;
-    button.blur(); // The button remains highlighted for some reason; kluge to fix.
+    button.blur(); // The button remains highlighted for some reason; kludge to fix.
     const options = { ...button.dataset };
     //const ignoreDefenseIds = JSON.parse(options.ignoreDefenseIdsJson) || [];
     const item = fromUuidSync(options.itemId);
@@ -1493,7 +1493,7 @@ async function _rollApplyKnockback(token, knockbackDice) {
 // Notice the chatListeners function in this file.
 export async function _onRollDamage(event) {
     const button = event.currentTarget;
-    button.blur(); // The button remains highlighted for some reason; kluge to fix.
+    button.blur(); // The button remains highlighted for some reason; kludge to fix.
     const toHitData = { ...button.dataset };
     const item = fromUuidSync(toHitData.itemId);
     const actor = item?.actor;
@@ -1567,7 +1567,7 @@ export async function _onRollDamage(event) {
 
     await damageRoller.roll();
 
-    // Kluge for SIMPLIFIED HEALING
+    // Kludge for SIMPLIFIED HEALING
     const isSimpleHealing = item.system.XMLID === "HEALING" && item.system.INPUT.match(/simplified/i);
 
     const damageRenderedResult = isSimpleHealing
@@ -1701,7 +1701,7 @@ export async function _onRollDamage(event) {
 export async function _onRollMindScan(event) {
     console.log(event);
     const button = event.currentTarget;
-    button.blur(); // The button remains highlighted for some reason; kluge to fix.
+    button.blur(); // The button remains highlighted for some reason; kludge to fix.
     const toHitData = { ...button.dataset };
     const item = fromUuidSync(event.currentTarget.dataset.itemId);
 
@@ -1755,7 +1755,7 @@ export async function _onRollMindScan(event) {
 
 export async function _onRollMindScanEffectRoll(event) {
     const button = event.currentTarget;
-    button.blur(); // The button remains highlighted for some reason; kluge to fix.
+    button.blur(); // The button remains highlighted for some reason; kludge to fix.
     const toHitData = { ...button.dataset };
     const item = fromUuidSync(event.currentTarget.dataset.itemId);
     const actor = item?.actor;
@@ -1931,86 +1931,32 @@ export async function _onApplyDamage(event) {
 
     const targetTokens = JSON.parse(damageData.tokenData);
 
-    // Sort tokenData based on distance to apply in distance order if this is an AoE
-    // TODO: pass other stuff through targetTokens and rename
-    // TODO: confirm I don't need to implement this... done when generating?
-    // if (item.getAoeModifier()) {
-    //     const aoeTemplate =
-    //         game.scenes.current.templates.find((o) => o.flags.itemId === item.id) ||
-    //         game.scenes.current.templates.find((o) => o.user.id === game.user.id);
-
-    //     targetsArray.sort(function (a, b) {
-    //         let distanceA = calculateDistanceBetween(aoeTemplate, game.scenes.current.tokens.get(a).object);
-    //         let distanceB = calculateDistanceBetween(aoeTemplate, game.scenes.current.tokens.get(b).object);
-    //         return distanceA - distanceB;
-    //     });
-    // }
-
     if (targetTokens.length === 0) {
         // Check to make sure we have a selected token
         if (canvas.tokens.controlled.length == 0) {
             return ui.notifications.warn(`You must select at least one token before applying damage.`);
         }
 
-        // TODO: How to get the damageData information for this? Would imply we need to pass an extra faux copy around. Wouldn't work for Explosions...
+        // PH: TODO: How to get the damageData information for this?
+        // PH: TODO: Need to figure out how to rebuild an attack for a random token since we could have damage that is related to range (explosion or reduced by range) ... call calcDamage again?
         for (const token of canvas.tokens.controlled) {
-            _onApplyDamageToSpecificToken(damageData, null /* TODO: will fail */, token.id);
+            _onApplyDamageToSpecificToken(damageData, null /* PH: TODO: will fail */, token.id);
         }
     } else {
         // Apply to all targets
         for (const targetToken of targetTokens) {
             const id = targetToken.token._id;
-            console.log(game.scenes.current.tokens.get(id).name);
             await _onApplyDamageToSpecificToken(damageData, targetToken.roller, id);
         }
-    }
-
-    return;
-
-    // TODO: Is else there anything here worth saving? I guess the canvas.tokens.controlled is useful.
-
-    // Single target
-    if (damageData.targetTokenId) {
-        return _onApplyDamageToSpecificToken(damageData, damageData.targetTokenId);
-    } else if (damageData.targetIds) {
-        // All targets
-        const item = fromUuidSync(event.currentTarget.dataset.itemId);
-        const targetsArray = damageData.targetIds.split(",");
-
-        // If AOE then sort by distance from center
-        if (item.hasExplosionAdvantage()) {
-            const aoeTemplate =
-                game.scenes.current.templates.find((o) => o.flags.itemId === item.id) ||
-                game.scenes.current.templates.find((o) => o.user.id === game.user.id);
-
-            targetsArray.sort(function (a, b) {
-                let distanceA = calculateDistanceBetween(aoeTemplate, game.scenes.current.tokens.get(a).object);
-                let distanceB = calculateDistanceBetween(aoeTemplate, game.scenes.current.tokens.get(b).object);
-                return distanceA - distanceB;
-            });
-        }
-
-        for (const id of targetsArray) {
-            console.log(game.scenes.current.tokens.get(id).name);
-            await _onApplyDamageToSpecificToken(damageData, id);
-        }
-        return;
-    }
-
-    // Check to make sure we have a selected token
-    if (canvas.tokens.controlled.length == 0) {
-        return ui.notifications.warn(`You must select at least one token before applying damage.`);
-    }
-
-    for (const token of canvas.tokens.controlled) {
-        _onApplyDamageToSpecificToken(damageData, token.id);
     }
 }
 
 export async function _onApplyDamageToSpecificToken(damageData, roller, tokenId) {
     const item = fromUuidSync(damageData.itemId);
 
-    const heroRoller = HeroRoller.fromJSON(roller || damageData.roller); // TODO: kludge only until null roller is resolved
+    // TODO: Figure out how to remove damageData.bodyDamage, damageData.bodyDamageEffective, damageData.stunDamage, damageData.stunDamageEffective
+
+    const heroRoller = HeroRoller.fromJSON(roller || damageData.roller); // PH: TODO: kludge only until null roller is resolved
 
     const token = canvas.tokens.get(tokenId);
     if (!token) {
@@ -3000,7 +2946,7 @@ async function _calcDamage(heroRoller, item, options) {
     let bodyForPenetrating = 0;
 
     if (adjustmentPower) {
-        // Kluge for SIMPLIFIED HEALING
+        // kludge for SIMPLIFIED HEALING
         if (item.system.XMLID === "HEALING" && item.system.INPUT.match(/simplified/i)) {
             const shr = await heroRoller.cloneWhileModifyingType(HeroRoller.ROLL_TYPE.NORMAL);
             body = shr.getBodyTotal();
@@ -3097,7 +3043,7 @@ async function _calcDamage(heroRoller, item, options) {
     // defenses (though it’s still resolved with one Attack Roll and
     // treated as a single attack).
     // This is super awkward with the current system.
-    // KLUGE: Apply body defense twice.
+    // kludge: Apply body defense twice.
     let REDUCEDPENETRATION = item.findModsByXmlid("REDUCEDPENETRATION");
     if (REDUCEDPENETRATION) {
         if (item.killing) {

--- a/module/item/item-attack.mjs
+++ b/module/item/item-attack.mjs
@@ -1587,7 +1587,7 @@ export async function _onRollDamage(event) {
 
     // Apply Damage button for specific targets
     let targetTokens = [];
-    for (const id of toHitData.targetids.split(",")) {
+    for (const id of toHitData.targetIds.split(",")) {
         let token = canvas.scene.tokens.get(id);
         if (token) {
             const entangleAE = token.actor?.temporaryEffects?.find((o) => o.flags?.XMLID === "ENTANGLE");
@@ -1639,7 +1639,7 @@ export async function _onRollDamage(event) {
 
     // If there is only 1 target then get rid of targetIds (which is used for Apply Damage ALL)
     if (targetTokens.length <= 1) {
-        delete toHitData.targetids;
+        delete toHitData.targetIds;
     }
 
     const cardData = {
@@ -1671,7 +1671,7 @@ export async function _onRollDamage(event) {
         roller: damageRoller.toJSON(),
 
         // misc
-        targetIds: toHitData.targetids,
+        targetIds: toHitData.targetIds,
         targetEntangle: toHitData.targetEntangle,
         tags: tags,
 
@@ -1895,7 +1895,7 @@ export async function _onRollMindScanEffectRoll(event) {
         roller: damageRoller.toJSON(),
 
         // misc
-        targetIds: toHitData.targetids,
+        targetIds: toHitData.targetIds,
         tags: tags,
 
         attackTags: getAttackTags(item),

--- a/module/item/item-attack.mjs
+++ b/module/item/item-attack.mjs
@@ -1201,8 +1201,8 @@ export async function _onRollAoeDamage(event) {
     const button = event.currentTarget;
     button.blur(); // The button remains highlighted for some reason; kluge to fix.
     const options = { ...button.dataset };
-    const item = fromUuidSync(options.itemid);
-    return AttackToHit(item, JSON.parse(options.formdata));
+    const item = fromUuidSync(options.itemId);
+    return AttackToHit(item, JSON.parse(options.formData));
 }
 
 export async function _onRollKnockback(event) {
@@ -1495,14 +1495,14 @@ export async function _onRollDamage(event) {
     const button = event.currentTarget;
     button.blur(); // The button remains highlighted for some reason; kluge to fix.
     const toHitData = { ...button.dataset };
-    const item = fromUuidSync(toHitData.itemid);
+    const item = fromUuidSync(toHitData.itemId);
     const actor = item?.actor;
 
     if (!actor) {
         return ui.notifications.error(`Attack details are no longer available.`);
     }
 
-    const action = JSON.parse(toHitData.actiondata);
+    const action = JSON.parse(toHitData.actionData);
 
     let effectiveItem = item;
 
@@ -1703,7 +1703,7 @@ export async function _onRollMindScan(event) {
     const button = event.currentTarget;
     button.blur(); // The button remains highlighted for some reason; kluge to fix.
     const toHitData = { ...button.dataset };
-    const item = fromUuidSync(event.currentTarget.dataset.itemid);
+    const item = fromUuidSync(event.currentTarget.dataset.itemId);
 
     const template2 = `systems/${HEROSYS.module}/templates/attack/item-mindscan-target-card.hbs`;
 
@@ -1757,7 +1757,7 @@ export async function _onRollMindScanEffectRoll(event) {
     const button = event.currentTarget;
     button.blur(); // The button remains highlighted for some reason; kluge to fix.
     const toHitData = { ...button.dataset };
-    const item = fromUuidSync(event.currentTarget.dataset.itemid);
+    const item = fromUuidSync(event.currentTarget.dataset.itemId);
     const actor = item?.actor;
 
     if (!actor) {
@@ -1926,18 +1926,16 @@ export async function _onRollMindScanEffectRoll(event) {
 // Notice the chatListeners function in this file.
 export async function _onApplyDamage(event) {
     const button = event.currentTarget;
-    button.blur(); // The button remains highlighted for some reason; kluge to fix.
-    const toHitData = { ...button.dataset };
-    const item = fromUuidSync(event.currentTarget.dataset.itemid);
+    button.blur(); // The button remains highlighted for some reason; kludge to fix.
+    const damageData = { ...button.dataset };
 
     // Single target
-    if (toHitData.targetTokenId) {
-        return _onApplyDamageToSpecificToken(event, toHitData.targetTokenId);
-    }
-
-    // All targets
-    if (toHitData.targetIds) {
-        const targetsArray = toHitData.targetIds.split(",");
+    if (damageData.targetTokenId) {
+        return _onApplyDamageToSpecificToken(damageData, damageData.targetTokenId);
+    } else if (damageData.targetIds) {
+        // All targets
+        const item = fromUuidSync(event.currentTarget.dataset.itemId);
+        const targetsArray = damageData.targetIds.split(",");
 
         // If AOE then sort by distance from center
         if (item.hasExplosionAdvantage()) {
@@ -1954,7 +1952,7 @@ export async function _onApplyDamage(event) {
 
         for (const id of targetsArray) {
             console.log(game.scenes.current.tokens.get(id).name);
-            await _onApplyDamageToSpecificToken(event, id);
+            await _onApplyDamageToSpecificToken(damageData, id);
         }
         return;
     }
@@ -1965,14 +1963,12 @@ export async function _onApplyDamage(event) {
     }
 
     for (const token of canvas.tokens.controlled) {
-        _onApplyDamageToSpecificToken(event, token.id);
+        _onApplyDamageToSpecificToken(damageData, token.id);
     }
 }
 
-export async function _onApplyDamageToSpecificToken(event, tokenId) {
-    const button = event.currentTarget;
-    const damageData = { ...button.dataset };
-    const item = fromUuidSync(damageData.itemid);
+export async function _onApplyDamageToSpecificToken(damageData, tokenId) {
+    const item = fromUuidSync(damageData.itemId);
 
     const heroRoller = HeroRoller.fromJSON(damageData.roller);
 
@@ -1990,7 +1986,7 @@ export async function _onApplyDamageToSpecificToken(event, tokenId) {
     if (!item) {
         // This typically happens when the attack id stored in the damage card no longer exists on the actor.
         // For example if the attack item was deleted or the HDC was uploaded again.
-        console.warn(damageData.itemid);
+        console.warn(damageData.itemId);
         return ui.notifications.error(`Attack details are no longer available.`);
     }
 
@@ -3529,7 +3525,8 @@ function calculateRequiredEnd(item, effectiveStr) {
 
         endToUse = itemEndurance;
 
-        // TODO: May want to get rid of this so we can support HKA with 0 STR (weird but possible?)
+        // TODO: May want to get rid of this so we can support HKA with 0 STR (weird but possible?) or
+        // attacks such as TK or EB which have no STR component.
         if (item.system.usesStrength || item.system.usesTk) {
             const strPerEnd =
                 item.actor.system.isHeroic && game.settings.get(HEROSYS.module, "StrEnd") === "five" ? 5 : 10;

--- a/module/utility/dice.mjs
+++ b/module/utility/dice.mjs
@@ -849,6 +849,14 @@ export class HeroRoller {
     }
 
     /**
+     *
+     * @returns {boolean}
+     */
+    hitLocationValid() {
+        return this._useHitLocation;
+    }
+
+    /**
      * Make a copy of this existing roller that can be modified without affecting the original.
      *
      * @returns HeroRoller

--- a/templates/attack/item-mindscan-target-card.hbs
+++ b/templates/attack/item-mindscan-target-card.hbs
@@ -17,14 +17,14 @@
             </div>
 
             <div class="mind-scan-buttons flexrow">
-                <button class="roll-mindscan-ego" data-itemId="{{item.uuid}}" data-target="{{targetTokenId}}" data-effective-levels="{{effectiveLevels}}" title="Character can establish Mind
+                <button class="roll-mindscan-ego" data-item-id="{{item.uuid}}" data-target="{{targetTokenId}}" data-effective-levels="{{effectiveLevels}}" title="Character can establish Mind
 Link or use first level of
 Telepathy (communication).
 They also know which
 direction the target is located.">
                     Mind Scan EGO
                 </button>
-            <button class="roll-mindscan-ego" data-itemId="{{item.uuid}}" data-target="{{targetTokenId}}" data-effective-levels="{{effectiveLevels}}" title="Character can establish Mind
+            <button class="roll-mindscan-ego" data-item-id="{{item.uuid}}" data-target="{{targetTokenId}}" data-effective-levels="{{effectiveLevels}}" title="Character can establish Mind
 Link or use first level of
 Telepathy (communication).
 They also know which
@@ -34,7 +34,7 @@ direction the target is located.">
             </div>
 
             <div class="mind-scan-buttons flexrow">
-                <button class="roll-mindscan-ego" data-itemId="{{item.uuid}}" data-target="{{targetTokenId}}" data-effective-levels="{{effectiveLevels}}" title="Character can use all Mental
+                <button class="roll-mindscan-ego" data-item-id="{{item.uuid}}" data-target="{{targetTokenId}}" data-effective-levels="{{effectiveLevels}}" title="Character can use all Mental
 Powers (including Powers that
 use OMCV against DMCV,
 have no Range Modifier, and
@@ -43,7 +43,7 @@ the target, and can estimate the
 distance to the target.">
                     Mind Scan EGO+10
                 </button>
-                <button class="roll-mindscan-ego" data-itemId="{{item.uuid}}" data-target="{{targetTokenId}}" data-effective-levels="{{effectiveLevels}}" title="Character can use all Mental
+                <button class="roll-mindscan-ego" data-item-id="{{item.uuid}}" data-target="{{targetTokenId}}" data-effective-levels="{{effectiveLevels}}" title="Character can use all Mental
 Powers (including Powers that
 use OMCV against DMCV,
 have no Range Modifier, and
@@ -55,12 +55,12 @@ distance to the target.">
             </div>
 
             <div class="mind-scan-buttons flexrow">
-                <button class="roll-mindscan-ego" data-itemId="{{item.uuid}}" data-target="{{targetTokenId}}" data-effective-levels="{{effectiveLevels}}" title="Character knows the exact
+                <button class="roll-mindscan-ego" data-item-id="{{item.uuid}}" data-target="{{targetTokenId}}" data-effective-levels="{{effectiveLevels}}" title="Character knows the exact
 location of the target. They can
 attack with all attacks.">
                     Mind Scan EGO+20
                 </button>
-                <button class="roll-mindscan-ego" data-itemId="{{item.uuid}}" data-target="{{targetTokenId}}" data-effective-levels="{{effectiveLevels}}" title="Character knows the exact
+                <button class="roll-mindscan-ego" data-item-id="{{item.uuid}}" data-target="{{targetTokenId}}" data-effective-levels="{{effectiveLevels}}" title="Character knows the exact
 location of the target. They can
 attack with all attacks.">
                     Undetectable EGO+40

--- a/templates/chat/item-damage-card.hbs
+++ b/templates/chat/item-damage-card.hbs
@@ -54,9 +54,11 @@
             {{#each targetTokens as |target id|}}
                 <button class="apply-damage" title="Apply damage to {{target.token.name}}." data-item-id="{{../item.uuid}}" data-action-data="{{actionData}}"
                     data-target-token-id="{{target.token.id}}"
+                    {{!-- Can these be removed? --}}
                     data-body-damage="{{../bodyDamage}}" data-body-damage-effective="{{../bodyDamageEffective}}"
                     data-stun-damage="{{../stunDamage}}" data-stun-damage-effective="{{../stunDamageEffective}}"
-                    data-roller="{{target.roller}}" data-stun-multiplier="{{../stunMultiplier}}" data-hit-location="{{../hitLocation}}" data-target-entangle="{{../targetEntangle}}">
+                    data-stun-multiplier="{{../stunMultiplier}}" data-hit-location="{{../hitLocation}}" data-target-entangle="{{../targetEntangle}}"
+                    data-token-data="{{jsonify target}}">
                     {{#if ../nonDmgEffect}}
                     Apply {{../item.system.XMLID}} to <b>{{target.token.name}}</b>
                     {{else}}
@@ -72,9 +74,11 @@
             {{#if targetIds}}
                 <button class="apply-damage" title="Apply damage to ALL tokens that were hit." data-item-id="{{item.uuid}}" data-action-data="{{actionData}}"
                     data-target-ids="{{targetIds}}"
+                    {{!-- Can these be removed? --}}
                     data-body-damage="{{bodyDamage}}" data-body-damage-effective="{{bodyDamageEffective}}"
                     data-stun-damage="{{stunDamage}}" data-stun-damage-effective="{{stunDamageEffective}}"
-                    data-roller="{{roller}}" data-stun-multiplier="{{stunMultiplier}}" data-hit-location="{{hitLocation}}" data-target-entangle="{{targetEntangle}}">
+                    data-stun-multiplier="{{stunMultiplier}}" data-hit-location="{{hitLocation}}" data-target-entangle="{{targetEntangle}}"
+                    data-token-data="{{jsonify targetTokens}}">
                     {{#if nonDmgEffect}}
                     Apply {{item.system.XMLID}} to <b>ALL</b>
                     {{else}}

--- a/templates/chat/item-damage-card.hbs
+++ b/templates/chat/item-damage-card.hbs
@@ -43,7 +43,7 @@
             <button class="apply-damage" title="Apply damage to selected tokens." data-item-id="{{item.uuid}}" data-action-data="{{actionData}}"
                 data-body-damage="{{bodyDamage}}" data-body-damage-effective="{{bodyDamageEffective}}"
                 data-stun-damage="{{stunDamage}}" data-stun-damage-effective="{{stunDamageEffective}}"
-                data-roller="{{roller}}" data-stun-multiplier="{{stunMultiplier}}" data-hit-location="{{hitLocation}}" data-target-Entangle="{{targetEntangle}}">
+                data-roller="{{roller}}" data-stun-multiplier="{{stunMultiplier}}" data-hit-location="{{hitLocation}}" data-target-entangle="{{targetEntangle}}">
                 {{#if (or nonDmgEffect senseAffecting)}}
                 Apply {{item.system.XMLID}}
                 {{else}}
@@ -56,7 +56,7 @@
                     data-target-token-id="{{target.token.id}}"
                     data-body-damage="{{../bodyDamage}}" data-body-damage-effective="{{../bodyDamageEffective}}"
                     data-stun-damage="{{../stunDamage}}" data-stun-damage-effective="{{../stunDamageEffective}}"
-                    data-roller="{{target.roller}}" data-stun-multiplier="{{../stunMultiplier}}" data-hit-location="{{../hitLocation}}" data-target-Entangle="{{../targetEntangle}}">
+                    data-roller="{{target.roller}}" data-stun-multiplier="{{../stunMultiplier}}" data-hit-location="{{../hitLocation}}" data-target-entangle="{{../targetEntangle}}">
                     {{#if ../nonDmgEffect}}
                     Apply {{../item.system.XMLID}} to <b>{{target.token.name}}</b>
                     {{else}}

--- a/templates/chat/item-damage-card.hbs
+++ b/templates/chat/item-damage-card.hbs
@@ -43,24 +43,25 @@
             <button class="apply-damage" title="Apply damage to selected tokens." data-item-id="{{item.uuid}}" data-action-data="{{actionData}}"
                 data-body-damage="{{bodyDamage}}" data-body-damage-effective="{{bodyDamageEffective}}"
                 data-stun-damage="{{stunDamage}}" data-stun-damage-effective="{{stunDamageEffective}}"
-                data-roller="{{roller}}" data-stun-multiplier="{{stunMultiplier}}" data-hit-location="{{hitLocation}}" data-target-entangle="{{targetEntangle}}">
+                data-roller="{{roller}}" data-stun-multiplier="{{stunMultiplier}}" data-hit-location="{{hitLocation}}" data-target-entangle="{{targetEntangle}}"
+                data-token-data="{{toJsonArray null}}">
                 {{#if (or nonDmgEffect senseAffecting)}}
-                Apply {{item.system.XMLID}}
+                    Apply {{item.system.XMLID}}
                 {{else}}
-                Apply Damage
+                    Apply Damage
                 {{/if}}
             </button>
 
             {{#each targetTokens as |target id|}}
                 <button class="apply-damage" title="Apply damage to {{target.token.name}}." data-item-id="{{../item.uuid}}" data-action-data="{{actionData}}"
                     data-target-token-id="{{target.token.id}}"
-                    {{!-- Can these be removed? --}}
+                    {{!-- PH: TODO: Can these be removed since the roller info should be in the targetTokens? --}}
                     data-body-damage="{{../bodyDamage}}" data-body-damage-effective="{{../bodyDamageEffective}}"
                     data-stun-damage="{{../stunDamage}}" data-stun-damage-effective="{{../stunDamageEffective}}"
                     data-stun-multiplier="{{../stunMultiplier}}" data-hit-location="{{../hitLocation}}" data-target-entangle="{{../targetEntangle}}"
-                    data-token-data="{{jsonify target}}">
+                    data-token-data="{{toJsonArray target}}">
                     {{#if ../nonDmgEffect}}
-                    Apply {{../item.system.XMLID}} to <b>{{target.token.name}}</b>
+                        Apply {{../item.system.XMLID}} to <b>{{target.token.name}}</b>
                     {{else}}
                         {{#if target.subTarget}}
                             Apply <span title="{{target.roller.title}}">{{target.roller.total}}</span> Damage to <b>{{target.subTarget}} {{item.system.XMLID}}</b>
@@ -78,11 +79,11 @@
                     data-body-damage="{{bodyDamage}}" data-body-damage-effective="{{bodyDamageEffective}}"
                     data-stun-damage="{{stunDamage}}" data-stun-damage-effective="{{stunDamageEffective}}"
                     data-stun-multiplier="{{stunMultiplier}}" data-hit-location="{{hitLocation}}" data-target-entangle="{{targetEntangle}}"
-                    data-token-data="{{jsonify targetTokens}}">
+                    data-token-data="{{toJSON targetTokens}}">
                     {{#if nonDmgEffect}}
-                    Apply {{item.system.XMLID}} to <b>ALL</b>
+                        Apply {{item.system.XMLID}} to <b>ALL</b>
                     {{else}}
-                    Apply Damage to <b>ALL</b>
+                        Apply Damage to <b>ALL</b>
                     {{/if}}
                 </button>
             {{/if}}

--- a/templates/chat/item-damage-card.hbs
+++ b/templates/chat/item-damage-card.hbs
@@ -40,11 +40,13 @@
         </div>
 
         <div data-visibility="gm">
-            <button class="apply-damage" title="Apply damage to selected tokens." data-item-id="{{item.uuid}}" data-action-data="{{actionData}}"
-                data-body-damage="{{bodyDamage}}" data-body-damage-effective="{{bodyDamageEffective}}"
-                data-stun-damage="{{stunDamage}}" data-stun-damage-effective="{{stunDamageEffective}}"
-                data-roller="{{roller}}" data-stun-multiplier="{{stunMultiplier}}" data-hit-location="{{hitLocation}}" data-target-entangle="{{targetEntangle}}"
-                data-token-data="{{toJsonArray null}}">
+            <button class="apply-damage"
+                title="Apply damage to selected tokens."
+                data-item-id="{{item.uuid}}"
+                data-action-data="{{actionDataJSON}}"
+                data-roller="{{rollerJSON}}"
+                data-target-tokens="{{toJsonArray null}}"
+            >
                 {{#if (or nonDmgEffect senseAffecting)}}
                     Apply {{item.system.XMLID}}
                 {{else}}
@@ -53,13 +55,13 @@
             </button>
 
             {{#each targetTokens as |target id|}}
-                <button class="apply-damage" title="Apply damage to {{target.token.name}}." data-item-id="{{../item.uuid}}" data-action-data="{{actionData}}"
-                    data-target-token-id="{{target.token.id}}"
-                    {{!-- PH: TODO: Can these be removed since the roller info should be in the targetTokens? --}}
-                    data-body-damage="{{../bodyDamage}}" data-body-damage-effective="{{../bodyDamageEffective}}"
-                    data-stun-damage="{{../stunDamage}}" data-stun-damage-effective="{{../stunDamageEffective}}"
-                    data-stun-multiplier="{{../stunMultiplier}}" data-hit-location="{{../hitLocation}}" data-target-entangle="{{../targetEntangle}}"
-                    data-token-data="{{toJsonArray target}}">
+                <button class="apply-damage"
+                    title="Apply damage to {{target.token.name}}"
+                    data-item-id="{{../item.uuid}}"
+                    data-action-data="{{../actionDataJSON}}"
+                    data-roller="{{../rollerJSON}}"
+                    data-target-tokens="{{toJsonArray target}}"
+                >
                     {{#if ../nonDmgEffect}}
                         Apply {{../item.system.XMLID}} to <b>{{target.token.name}}</b>
                     {{else}}
@@ -72,14 +74,14 @@
                 </button>
             {{/each}}
 
-            {{#if targetIds}}
-                <button class="apply-damage" title="Apply damage to ALL tokens that were hit." data-item-id="{{item.uuid}}" data-action-data="{{actionData}}"
-                    data-target-ids="{{targetIds}}"
-                    {{!-- Can these be removed? --}}
-                    data-body-damage="{{bodyDamage}}" data-body-damage-effective="{{bodyDamageEffective}}"
-                    data-stun-damage="{{stunDamage}}" data-stun-damage-effective="{{stunDamageEffective}}"
-                    data-stun-multiplier="{{stunMultiplier}}" data-hit-location="{{hitLocation}}" data-target-entangle="{{targetEntangle}}"
-                    data-token-data="{{toJSON targetTokens}}">
+            {{#if (gt targetTokens.length 1)}}
+                <button class="apply-damage"
+                    title="Apply damage to ALL tokens that were hit"
+                    data-item-id="{{item.uuid}}"
+                    data-action-data="{{actionDataJSON}}"
+                    data-roller="{{rollerJSON}}"
+                    data-tokens="{{toJSON targetTokens}}"
+                >
                     {{#if nonDmgEffect}}
                         Apply {{item.system.XMLID}} to <b>ALL</b>
                     {{else}}

--- a/templates/chat/item-damage-card.hbs
+++ b/templates/chat/item-damage-card.hbs
@@ -56,19 +56,19 @@
 
             {{#each targetTokens as |target id|}}
                 <button class="apply-damage"
-                    title="Apply damage to {{target.token.name}}"
+                    title="Apply damage to {{target.name}}"
                     data-item-id="{{../item.uuid}}"
                     data-action-data="{{../actionDataJSON}}"
                     data-roller="{{../rollerJSON}}"
                     data-target-tokens="{{toJsonArray target}}"
                 >
                     {{#if ../nonDmgEffect}}
-                        Apply {{../item.system.XMLID}} to <b>{{target.token.name}}</b>
+                        Apply {{../item.system.XMLID}} to <b>{{target.name}}</b>
                     {{else}}
                         {{#if target.subTarget}}
                             Apply <span title="{{target.roller.title}}">{{target.roller.total}}</span> Damage to <b>{{target.subTarget}} {{item.system.XMLID}}</b>
                         {{else}}
-                            Apply <span title="{{target.roller.title}}">{{target.roller.total}}</span> Damage to <b>{{target.token.name}} {{item.system.XMLID}}</b>
+                            Apply <span title="{{target.roller.title}}">{{target.roller.total}}</span> Damage to <b>{{target.name}} {{item.system.XMLID}}</b>
                         {{/if}}
                     {{/if}}
                 </button>
@@ -80,7 +80,7 @@
                     data-item-id="{{item.uuid}}"
                     data-action-data="{{actionDataJSON}}"
                     data-roller="{{rollerJSON}}"
-                    data-tokens="{{toJSON targetTokens}}"
+                    data-target-tokens="{{toJSON targetTokens}}"
                 >
                     {{#if nonDmgEffect}}
                         Apply {{item.system.XMLID}} to <b>ALL</b>

--- a/templates/chat/item-damage-card.hbs
+++ b/templates/chat/item-damage-card.hbs
@@ -40,7 +40,7 @@
         </div>
 
         <div data-visibility="gm">
-            <button class="apply-damage" title="Apply damage to selected tokens." data-itemId="{{item.uuid}}" data-action-data="{{actionData}}"
+            <button class="apply-damage" title="Apply damage to selected tokens." data-item-id="{{item.uuid}}" data-action-data="{{actionData}}"
                 data-body-damage="{{bodyDamage}}" data-body-damage-effective="{{bodyDamageEffective}}"
                 data-stun-damage="{{stunDamage}}" data-stun-damage-effective="{{stunDamageEffective}}"
                 data-roller="{{roller}}" data-stun-multiplier="{{stunMultiplier}}" data-hit-location="{{hitLocation}}" data-target-Entangle="{{targetEntangle}}">
@@ -52,35 +52,35 @@
             </button>
 
             {{#each targetTokens as |target id|}}
-            <button class="apply-damage" title="Apply damage to {{target.token.name}}." data-itemId="{{../item.uuid}}" data-action-data="{{actionData}}"
-                data-target-token-id="{{target.token.id}}"
-                data-body-damage="{{../bodyDamage}}" data-body-damage-effective="{{../bodyDamageEffective}}"
-                data-stun-damage="{{../stunDamage}}" data-stun-damage-effective="{{../stunDamageEffective}}"
-                data-roller="{{target.roller}}" data-stun-multiplier="{{../stunMultiplier}}" data-hit-location="{{../hitLocation}}" data-target-Entangle="{{../targetEntangle}}">
-                {{#if ../nonDmgEffect}}
-                Apply {{../item.system.XMLID}} to <b>{{target.token.name}}</b>
-                {{else}}
-                    {{#if target.subTarget}}
-                        Apply <span title="{{target.roller.title}}">{{target.roller.total}}</span> Damage to <b>{{target.subTarget}} {{item.system.XMLID}}</b>
+                <button class="apply-damage" title="Apply damage to {{target.token.name}}." data-item-id="{{../item.uuid}}" data-action-data="{{actionData}}"
+                    data-target-token-id="{{target.token.id}}"
+                    data-body-damage="{{../bodyDamage}}" data-body-damage-effective="{{../bodyDamageEffective}}"
+                    data-stun-damage="{{../stunDamage}}" data-stun-damage-effective="{{../stunDamageEffective}}"
+                    data-roller="{{target.roller}}" data-stun-multiplier="{{../stunMultiplier}}" data-hit-location="{{../hitLocation}}" data-target-Entangle="{{../targetEntangle}}">
+                    {{#if ../nonDmgEffect}}
+                    Apply {{../item.system.XMLID}} to <b>{{target.token.name}}</b>
                     {{else}}
-                        Apply <span title="{{target.roller.title}}">{{target.roller.total}}</span> Damage to <b>{{target.token.name}} {{item.system.XMLID}}</b>
+                        {{#if target.subTarget}}
+                            Apply <span title="{{target.roller.title}}">{{target.roller.total}}</span> Damage to <b>{{target.subTarget}} {{item.system.XMLID}}</b>
+                        {{else}}
+                            Apply <span title="{{target.roller.title}}">{{target.roller.total}}</span> Damage to <b>{{target.token.name}} {{item.system.XMLID}}</b>
+                        {{/if}}
                     {{/if}}
-                {{/if}}
-            </button>
+                </button>
             {{/each}}
 
             {{#if targetIds}}
-            <button class="apply-damage" title="Apply damage to ALL tokens that were hit." data-itemId="{{item.uuid}}" data-action-data="{{actionData}}"
-                data-target-Ids="{{targetIds}}"
-                data-body-damage="{{bodyDamage}}" data-body-damage-effective="{{bodyDamageEffective}}"
-                data-stun-damage="{{stunDamage}}" data-stun-damage-effective="{{stunDamageEffective}}"
-                data-roller="{{roller}}" data-stun-multiplier="{{stunMultiplier}}" data-hit-location="{{hitLocation}}" data-target-Entangle="{{targetEntangle}}">
-                {{#if nonDmgEffect}}
-                Apply {{item.system.XMLID}} to <b>ALL</b>
-                {{else}}
-                Apply Damage to <b>ALL</b>
-                {{/if}}
-            </button>
+                <button class="apply-damage" title="Apply damage to ALL tokens that were hit." data-item-id="{{item.uuid}}" data-action-data="{{actionData}}"
+                    data-target-ids="{{targetIds}}"
+                    data-body-damage="{{bodyDamage}}" data-body-damage-effective="{{bodyDamageEffective}}"
+                    data-stun-damage="{{stunDamage}}" data-stun-damage-effective="{{stunDamageEffective}}"
+                    data-roller="{{roller}}" data-stun-multiplier="{{stunMultiplier}}" data-hit-location="{{hitLocation}}" data-target-entangle="{{targetEntangle}}">
+                    {{#if nonDmgEffect}}
+                    Apply {{item.system.XMLID}} to <b>ALL</b>
+                    {{else}}
+                    Apply Damage to <b>ALL</b>
+                    {{/if}}
+                </button>
             {{/if}}
         </div>
 

--- a/templates/chat/item-toHit-card.hbs
+++ b/templates/chat/item-toHit-card.hbs
@@ -119,15 +119,13 @@
                 <i>The Game Master is reviewing the target to confirm it is within the Mind Scan area and that your attack score exceeded the target's DMCV.</i>
             </div>
 
-            <button data-visibility="gm" class="roll-mindscan" data-itemId="{{item.uuid}}" data-aim="{{aim}}" data-aim-side="{{aimSide}}"
-                data-damageMod="{{damageMod}}" data-hitRollData="{{hitRollData}}"
+            <button data-visibility="gm" class="roll-mindscan" data-item-id="{{item.uuid}}" data-aim="{{aim}}" data-aim-side="{{aimSide}}"
                 data-effectiveStr="{{effectiveStr}}" data-effective-Levels="{{effectiveLevels}}" data-targetIds="{{targetIds}}" data-velocity="{{velocity}}" 
                 data-boostable-Charges="{{boostableChargesToUse}}" data-to-hit-roll-total="{{toHitRollTotal}}" data-target="" title="Will result in a MISS">
                 No Target or Miss
             </button>
 
-            <button data-visibility="gm" class="roll-mindscan" data-itemId="{{item.uuid}}" data-aim="{{aim}}" data-aim-side="{{aimSide}}"
-                data-damageMod="{{damageMod}}" data-hitRollData="{{hitRollData}}"
+            <button data-visibility="gm" class="roll-mindscan" data-item-id="{{item.uuid}}" data-aim="{{aim}}" data-aim-side="{{aimSide}}"
                 data-effectiveStr="{{effectiveStr}}" data-effective-Levels="{{effectiveLevels}}" data-targetIds="{{targetIds}}" data-velocity="{{velocity}}" 
                 data-boostable-Charges="{{boostableChargesToUse}}" data-to-hit-roll-total="{{toHitRollTotal}}" data-target="Selected" title="Select a token on the scene">
                 Selected Token
@@ -135,8 +133,7 @@
 
             {{#each targetData as |target|}}
                 {{#if (eq target.result.hit "Hit")}}
-                    <button data-visibility="gm" class="roll-mindscan" data-itemId="{{../item.uuid}}" data-aim="{{../aim}}" data-aim-side="{{../aimSide}}"
-                        data-damageMod="{{../damageMod}}" data-hitRollData="{{../hitRollData}}"
+                    <button data-visibility="gm" class="roll-mindscan" data-item-id="{{../item.uuid}}" data-aim="{{../aim}}" data-aim-side="{{../aimSide}}"
                         data-effectiveStr="{{../effectiveStr}}" data-effective-Levels="{{../effectiveLevels}}" data-targetIds="{{../targetIds}}" data-velocity="{{../velocity}}" 
                         data-boostable-Charges="{{../boostableChargesToUse}}" data-target-Entangle="{{targetEntangle}}" data-to-hit-roll-total="{{../toHitRollTotal}}" data-target="{{this.id}}">
                         <b>{{this.name}}</b>
@@ -145,8 +142,8 @@
             {{/each}}
         {{else}}
             <div data-visibility="{{actor.id}}">
-                <button class="roll-damage" data-itemId="{{item.uuid}}" data-aim="{{aim}}" data-aim-side="{{aimSide}}"
-                    data-damageMod="{{damageMod}}" data-hitRollData="{{hitRollData}}" data-actionData="{{actionData}}"
+                <button class="roll-damage" data-item-id="{{item.uuid}}" data-aim="{{aim}}" data-aim-side="{{aimSide}}"
+                    data-action-data="{{actionData}}"
                     data-effectiveStr="{{effectiveStr}}" data-effective-Levels="{{effectiveLevels}}" data-targetIds="{{targetIds}}" data-velocity="{{velocity}}" 
                     data-boostable-Charges="{{boostableChargesToUse}}" data-target-Entangle="{{targetEntangle}}">
                     {{#if (or adjustment senseAffecting)}}

--- a/templates/chat/item-toHit-card.hbs
+++ b/templates/chat/item-toHit-card.hbs
@@ -120,13 +120,13 @@
             </div>
 
             <button data-visibility="gm" class="roll-mindscan" data-item-id="{{item.uuid}}" data-aim="{{aim}}" data-aim-side="{{aimSide}}"
-                data-effectiveStr="{{effectiveStr}}" data-effective-Levels="{{effectiveLevels}}" data-targetIds="{{targetIds}}" data-velocity="{{velocity}}" 
+                data-effectiveStr="{{effectiveStr}}" data-effective-levels="{{effectiveLevels}}" data-target-ids="{{targetIds}}" data-velocity="{{velocity}}" 
                 data-boostable-Charges="{{boostableChargesToUse}}" data-to-hit-roll-total="{{toHitRollTotal}}" data-target="" title="Will result in a MISS">
                 No Target or Miss
             </button>
 
             <button data-visibility="gm" class="roll-mindscan" data-item-id="{{item.uuid}}" data-aim="{{aim}}" data-aim-side="{{aimSide}}"
-                data-effectiveStr="{{effectiveStr}}" data-effective-Levels="{{effectiveLevels}}" data-targetIds="{{targetIds}}" data-velocity="{{velocity}}" 
+                data-effectiveStr="{{effectiveStr}}" data-effective-levels="{{effectiveLevels}}" data-target-ids="{{targetIds}}" data-velocity="{{velocity}}" 
                 data-boostable-Charges="{{boostableChargesToUse}}" data-to-hit-roll-total="{{toHitRollTotal}}" data-target="Selected" title="Select a token on the scene">
                 Selected Token
             </button>
@@ -134,8 +134,8 @@
             {{#each targetData as |target|}}
                 {{#if (eq target.result.hit "Hit")}}
                     <button data-visibility="gm" class="roll-mindscan" data-item-id="{{../item.uuid}}" data-aim="{{../aim}}" data-aim-side="{{../aimSide}}"
-                        data-effectiveStr="{{../effectiveStr}}" data-effective-Levels="{{../effectiveLevels}}" data-targetIds="{{../targetIds}}" data-velocity="{{../velocity}}" 
-                        data-boostable-Charges="{{../boostableChargesToUse}}" data-target-Entangle="{{targetEntangle}}" data-to-hit-roll-total="{{../toHitRollTotal}}" data-target="{{this.id}}">
+                        data-effectiveStr="{{../effectiveStr}}" data-effective-levels="{{../effectiveLevels}}" data-target-ids="{{../targetIds}}" data-velocity="{{../velocity}}" 
+                        data-boostable-charges="{{../boostableChargesToUse}}" data-target-entangle="{{targetEntangle}}" data-to-hit-roll-total="{{../toHitRollTotal}}" data-target="{{this.id}}">
                         <b>{{this.name}}</b>
                     </button>
                 {{/if}}
@@ -144,8 +144,8 @@
             <div data-visibility="{{actor.id}}">
                 <button class="roll-damage" data-item-id="{{item.uuid}}" data-aim="{{aim}}" data-aim-side="{{aimSide}}"
                     data-action-data="{{actionData}}"
-                    data-effectiveStr="{{effectiveStr}}" data-effective-Levels="{{effectiveLevels}}" data-targetIds="{{targetIds}}" data-velocity="{{velocity}}" 
-                    data-boostable-Charges="{{boostableChargesToUse}}" data-target-Entangle="{{targetEntangle}}">
+                    data-effectiveStr="{{effectiveStr}}" data-effective-levels="{{effectiveLevels}}" data-target-ids="{{targetIds}}" data-velocity="{{velocity}}" 
+                    data-boostable-charges="{{boostableChargesToUse}}" data-target-entangle="{{targetEntangle}}">
                     {{#if (or adjustment senseAffecting)}}
                         Roll {{item.system.XMLID}}
                     {{else}}

--- a/templates/chat/item-toHitAoe-card.hbs
+++ b/templates/chat/item-toHitAoe-card.hbs
@@ -62,7 +62,7 @@
         </div>
 
         <div data-visibility="{{actor.id}}">
-            <button class="rollAoe-damage" data-itemId="{{item.uuid}}" data-formData="{{formData}}">
+            <button class="rollAoe-damage" data-item-id="{{item.uuid}}" data-form-data="{{formData}}">
                 {{{buttonText}}}
             </button>
         </div>


### PR DESCRIPTION
Ensure that all damage rolls are correctly applied to unique targets by simplifying the damage rolling step (`_onRollDamage`). It now, shockingly, only rolls the damage. The rest is done when applying the attack. Consequently `_onApplyDamage ` gets a bit more complex but could probably use a good refactoring anyways.

Relates to #1323 