### PR TITLE
fix(KO): KO'd characters only take double damage, not double adjust etc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Inobivous powers no longer show for Actor Description.
 - Fixed the chat card name of Adjustment powers that targeted POWERs. Was showing attack item, not target power. [#1608](https://github.com/dmdorman/hero6e-foundryvtt/issues/1608)
 - Fixed formatting issues with prosemirror editor caused by us overriding some css that we shouldn't have. [#1629](https://github.com/dmdorman/hero6e-foundryvtt/issues/1629)
+- Knocked out targets no longer get double adjustment effect. [#1255](https://github.com/dmdorman/hero6e-foundryvtt/issues/1255)
+- Explosions now correctly deal different damage to each token based on distance when using the "Apply Damage to ALL" button. [#1323](https://github.com/dmdorman/hero6e-foundryvtt/issues/1323)
 
 ## Version 4.0.12 [Hero System 6e (Unofficial) v2](https://github.com/dmdorman/hero6e-foundryvtt)
 

--- a/module/actor/actor.mjs
+++ b/module/actor/actor.mjs
@@ -12,7 +12,6 @@ import { RoundFavorPlayerDown, RoundFavorPlayerUp } from "../utility/round.mjs";
  * @extends {Actor}
  */
 export class HeroSystem6eActor extends Actor {
-
     /** @inheritdoc */
     async _preCreate(data, options, user) {
         await super._preCreate(data, options, user);

--- a/module/item/item-attack.mjs
+++ b/module/item/item-attack.mjs
@@ -2946,6 +2946,13 @@ async function _calcDamage(heroRoller, item, options) {
         } else {
             bodyForPenetrating = body;
         }
+
+        // Knocked out targets take double STUN damage from attacks
+        const targetActor = (game.scenes.current.tokens.get(options.targetTokenId) || options.targetToken)?.actor;
+        if (targetActor?.statuses.has("knockedOut")) {
+            effects += "Knocked Out x2 STUN;";
+            stun *= 2;
+        }
     }
 
     const noHitLocationsPower = !!item.system.noHitLocations;
@@ -2979,12 +2986,6 @@ async function _calcDamage(heroRoller, item, options) {
     let effects = "";
     if (item.system.EFFECT) {
         effects = item.system.EFFECT + "; ";
-    }
-
-    const targetActor = (game.scenes.current.tokens.get(options.targetTokenId) || options.targetToken)?.actor;
-    if (targetActor?.statuses.has("knockedOut")) {
-        effects += "Knocked Out x2 STUN;";
-        stun *= 2;
     }
 
     // VULNERABILITY


### PR DESCRIPTION
Resolves #1255