### PR TITLE
fix(to-hit locations): fix for AoE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - PD and ED from AID is now applying to defenses. [#1695](https://github.com/dmdorman/hero6e-foundryvtt/issues/1695)
 - Fixed Penalty Skill Levels for range. [#1734](https://github.com/dmdorman/hero6e-foundryvtt/issues/1734)
+- Fixed AoE with Hit Locations and now show more hit location info in to-hit dialog. [#1768](https://github.com/dmdorman/hero6e-foundryvtt/issues/1768)
 
 ## Version 4.0.14 20250119
 

--- a/module/item/item-attack.mjs
+++ b/module/item/item-attack.mjs
@@ -106,8 +106,6 @@ export async function collectActionDataBeforeToHitOptions(item) {
         data.velocitySystemUnits = getSystemDisplayUnits(item.is5e);
     }
 
-    const aoe = item.getAoeModifier();
-
     await new ItemAttackFormApplication(data).render(true);
 }
 

--- a/module/item/item-attack.mjs
+++ b/module/item/item-attack.mjs
@@ -108,14 +108,6 @@ export async function collectActionDataBeforeToHitOptions(item) {
 
     const aoe = item.getAoeModifier();
 
-    // TODO: This needs to be considered. AOE does not preclude hit locations.
-    if (game.settings.get(HEROSYS.module, "hit locations") && !item.system.noHitLocations && !aoe) {
-        data.useHitLoc = true;
-        //data.hitLoc = CONFIG.HERO.hitLocations;
-        data.hitLocSide =
-            game.settings.get(HEROSYS.module, "hitLocTracking") === "all" ? CONFIG.HERO.hitLocationSide : null;
-    }
-
     await new ItemAttackFormApplication(data).render(true);
 }
 

--- a/templates/attack/item-attack-application.hbs
+++ b/templates/attack/item-attack-application.hbs
@@ -132,27 +132,26 @@
 
 
       {{!-- Aim (hit location) form group --}}
-      {{#if useHitLoc}}
-      <div class="form-group">
-        <label>Aim</label>
-        <select name="aim" style="max-width:234px">
-          {{selectOptions hitLoc selected=aim nameAttr="key" labelAttr="label" disabled="disabled"}}
-        </select>
-      </div>
+      {{#if hitLocationsEnabled}}
+        <div class="form-group">
+          <label>Aim</label>
+          <select name="aim" style="max-width:234px">
+            {{selectOptions hitLoc selected=aim valueAttr="key" labelAttr="label" disabled="disabled"}}
+          </select>
+        </div>
       {{/if}}
 
       {{!-- Aim side (hit location side) form group --}}
-      {{#if hitLocSide}}
-      <div class="form-group">
-        <label>Aim Side</label>
-        <select name="aimSide" id="aimSide">
-          <option value="none">None</option>
-          {{#each hitLocSide as |hitLocSide key|}}
-            <option value={{key}}{{#if (eq key @root/aimSide)}} selected{{/if}}>{{key}}</option>
-          {{/each}}
-        </select>
-      </div>
+      {{#if hitLocationSideEnabled}}
+        <div class="form-group">
+          <label>Aim Side</label>
+          <select name="aimSide" id="aimSide">
+            {{selectOptions hitLocSide selected=aimSide valueAttr="key" labelAttr="label" disabled="disabled"}}
+          </select>
+        </div>
       {{/if}}
+
+
 
       {{#if mindScanChoices}}
         <div class="form-group">


### PR DESCRIPTION
Make sure `aim` is always set even for AoE.

Also provide more information about why a placed shot is not permitted.