### PR TITLE
Ph balance/aoe range penalty tag consolidation

### DIFF
--- a/module/config.mjs
+++ b/module/config.mjs
@@ -298,7 +298,7 @@ HERO.hitLocations = Object.freeze({
 });
 
 HERO.isSpecialHitLocation = function (location) {
-    return HERO.hitLocations[location].isSpecialHl;
+    return HERO.hitLocations[location]?.isSpecialHl ?? false;
 };
 
 HERO.sidedLocations = new Set(["Hand", "Shoulder", "Arm", "Thigh", "Leg", "Foot"]);

--- a/module/item/item-attack.mjs
+++ b/module/item/item-attack.mjs
@@ -258,9 +258,9 @@ export async function doAoeActionToHit(item, options) {
         return ui.notifications.error(`Attack AOE template was not found.`);
     }
 
-    const distanceToken = calculateDistanceBetween(aoeTemplate, token).distance;
+    const distance = calculateDistanceBetween(aoeTemplate, token).distance;
     let dcvTargetNumber = 0;
-    if (distanceToken > (actor.system.is5e ? 1 : 2)) {
+    if (distance > (actor.system.is5e ? 1 : 2)) {
         dcvTargetNumber = 3;
     }
 
@@ -297,7 +297,7 @@ export async function doAoeActionToHit(item, options) {
             normalRange
         )
     ) {
-        const rangePenalty = -calculateRangePenaltyFromDistanceInMetres(distanceToken);
+        const rangePenalty = -calculateRangePenaltyFromDistanceInMetres(distance, actor);
 
         // PENALTY_SKILL_LEVELS (range)
         const pslRange = penaltySkillLevelsForAttack(item).find(
@@ -309,7 +309,10 @@ export async function doAoeActionToHit(item, options) {
         }
 
         if (rangePenalty) {
-            attackHeroRoller.addNumber(rangePenalty, "Range penalty");
+            attackHeroRoller.addNumber(
+                rangePenalty,
+                `Range penalty (${getRoundedDownDistanceInSystemUnits(distance, item.actor)}${getSystemDisplayUnits(item.actor.is5e)})`,
+            );
         }
 
         // Brace (+2 OCV only to offset the Range Modifier)
@@ -421,9 +424,7 @@ export async function doAoeActionToHit(item, options) {
         await facingHeroRoller.roll();
         const facingRollResult = facingHeroRoller.getBasicTotal();
 
-        const moveDistance = RoundFavorPlayerDown(
-            Math.min(distanceToken / 2, item.actor.system.is5e ? missBy : missBy * 2),
-        );
+        const moveDistance = RoundFavorPlayerDown(Math.min(distance / 2, item.actor.system.is5e ? missBy : missBy * 2));
         hitRollText = `AOE origin MISSED by ${missBy}. Move AOE origin ${
             moveDistance + getSystemDisplayUnits(item.actor.is5e)
         } in the <b>${facingRollResult}</b> direction.`;
@@ -662,7 +663,7 @@ async function doSingleTargetActionToHit(item, options) {
 
         const target = targets[0];
         const distance = token ? calculateDistanceBetween(token, target).distance : 0;
-        const rangePenalty = -calculateRangePenaltyFromDistanceInMetres(distance);
+        const rangePenalty = -calculateRangePenaltyFromDistanceInMetres(distance, actor);
 
         // PENALTY_SKILL_LEVELS (range)
         const pslRange = penaltySkillLevelsForAttack(item).find(

--- a/module/item/item-attack.mjs
+++ b/module/item/item-attack.mjs
@@ -661,7 +661,17 @@ async function doSingleTargetActionToHit(item, options) {
             ui.notifications.warn(`${actor.name} has no token in this scene.  Range penalties will be ignored.`);
         }
 
-        const target = targets[0];
+        const isAoE = item.getAoeModifier();
+        const aoeTemplate =
+            game.scenes.current.templates.find((o) => o.flags.itemId === item.id) ||
+            game.scenes.current.templates.find((o) => o.author.id === game.user.id);
+        if (isAoE && !aoeTemplate) {
+            return ui.notifications.error(`Attack AOE template was not found.`);
+        }
+
+        // Pick the appropriate target based on the attack type. For AoE it's the base of the AoE template for
+        // a single target attack it's the actual target.
+        const target = isAoE ? aoeTemplate : targets[0];
         const distance = token ? calculateDistanceBetween(token, target).distance : 0;
         const rangePenalty = -calculateRangePenaltyFromDistanceInMetres(distance, actor);
 


### PR DESCRIPTION
- Consolidate range penalty tags so that the AoE path show the distance to the AoE template base
- Fix penalty range calculation to target for AoE (doesn't actually affect anything but make consistent) by making the range between the attacker and the AoE template base rather than the target.
- Fix special hit location problem with AoEs

Resolves #2128 