### PR TITLE
item corruption

### DIFF
--- a/module/item/item-attack-application.mjs
+++ b/module/item/item-attack-application.mjs
@@ -268,7 +268,7 @@ export class ItemAttackFormApplication extends FormApplication {
                         (linkedEndInfo) => linkedEndInfo.item,
                     ),
                     ...(this.data.effectiveItem.system._active.linkedAssociated || []).map(
-                        (linkedInfo) => linkedInfo.item,
+                        (linkedAssociatedInfo) => linkedAssociatedInfo.item,
                     ),
 
                     // PH: FIXME: This should probably be recursive as these linked items could have linked endurance

--- a/module/item/item.mjs
+++ b/module/item/item.mjs
@@ -1093,11 +1093,6 @@ export class HeroSystem6eItem extends Item {
     }
 
     // An attempt to cache getPowerInfo for performance reasons.
-    //_baseInfo ??= getPowerInfo({ item: this, xmlTag: this.system.xmlTag });
-    getBaseInfo() {
-        console.warn("Use baseInfo instead of getBaseInfo");
-        return this.baseInfo;
-    }
     get baseInfo() {
         // cache getPowerInfo
         this._baseInfo ??= getPowerInfo({ item: this, xmlTag: this.system.xmlTag });

--- a/module/utility/damage.mjs
+++ b/module/utility/damage.mjs
@@ -534,12 +534,7 @@ export function calculateAddedDicePartsFromItem(item, baseDamageItem, options) {
     // Skill Roll or have TF: SCUBA. A character who stands
     // in water while he fights is at -2 DCV (and typically also suffer
     // Poor Footing penalties) unless he makes a Breakfall roll.
-    if (
-        item.actor?.statuses?.has("underwater")
-        // &&
-        // (baseDamageItem.system.XMLID === "__STRENGTHDAMAGE" ||
-        //     baseDamageItem.system.ALIAS === "__InternalStrengthPlaceholder")
-    ) {
+    if (item.actor?.statuses?.has("underwater")) {
         const underwaterDc = 2; // NOTE: Working with 2 DC and then subtracting
         const underwaterDiceParts = calculateDicePartsFromDcForItem(baseDamageItem, underwaterDc);
         const formula = dicePartsToFullyQualifiedEffectFormula(baseDamageItem, underwaterDiceParts);


### PR DESCRIPTION
foundry.utils.deepClone doesn't work on "complex" class objects and doesn't tell you it failed unless you pass in {strict: true}. Don't close, just be careful about building up the dehydrated object.