### PR TITLE
darkness crash correction

### DIFF
--- a/module/config.mjs
+++ b/module/config.mjs
@@ -5218,19 +5218,20 @@ function addPower(powerDescription6e, powerOverrideFor5e) {
             behaviors: ["to-hit"],
             perceivability: "obvious",
             costPerLevel: function (item) {
+                const is5e = item.is5e;
                 switch (item.system.OPTIONID) {
                     case "SIGHTGROUP":
-                        return 5; // Targeting sense gruop
+                        return is5e ? 10 : 5; // Targeting sense gruop
                     case "HEARINGGROUP":
                     case "MENTALGROUP":
                     case "RADIOGROUP":
                     case "SMELLGROUP":
                     case "TOUCHGROUP":
-                        return 3; // Non-targeting sense group
+                        return is5e ? 5 : 3; // Non-targeting sense group
                     default:
                         console.error(`DARKNESS OPTIONID ${item.system.OPTIONID} is not handled`);
                 }
-                return 5;
+                return is5e ? 10 : 5;
             },
             duration: "constant",
             range: HERO.RANGE_TYPES.STANDARD,

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -548,7 +548,7 @@ function noDamageBaseEffectDicePartsBundle(item /* , _options */) {
             constant: 0,
         },
         tags: [{ value: "0", name: `BAD TAG`, title: "Should not have been called. Please report." }],
-        baseAttackItem: null,
+        baseAttackItem: item,
     };
 }
 

--- a/module/herosystem6e.mjs
+++ b/module/herosystem6e.mjs
@@ -723,35 +723,6 @@ Hooks.on("updateWorldTime", async (worldTime, options) => {
                 }
             }
 
-            // Charges Recover each day
-            // if (today > lastDate) {
-            //     const itemsWithCharges = actor.items.filter((item) => item.system.charges?.max);
-            //     let content = "";
-            //     for (const item of itemsWithCharges) {
-            //         let value = parseInt(item.system.charges.value);
-            //         let max = parseInt(item.system.charges.max);
-            //         if (value < max) {
-            //             content += `Charges recover at midnight:  ${actor.name}/${item.name} ${value} to ${max} charges.  `;
-            //             item.update({ "system.charges.value": max });
-            //         }
-            //     }
-
-            //     if (content) {
-            //         const chatData = {
-            //             author: game.user.id,
-            //             whisper: [
-            //                 ...ChatMessage.getWhisperRecipients(actor.name),
-            //                 ...ChatMessage.getWhisperRecipients("GM"),
-            //             ],
-            //             speaker: ChatMessage.getSpeaker({ actor: actor }),
-            //             blind: true,
-            //             content: content,
-            //         };
-            //         //await
-            //         ChatMessage.create(chatData);
-            //     }
-            // }
-
             // Update Flash name?
             const flashEffects = actor.temporaryEffects.filter((o) => ["FLASH", "MANEUVER"].includes(o.flags.XMLID));
             for (const flashAe of flashEffects) {

--- a/module/item/item.mjs
+++ b/module/item/item.mjs
@@ -5340,7 +5340,7 @@ export class HeroSystem6eItem extends Item {
 
         // Custom basePoints
         if (this.baseInfo?.cost) {
-            return this.baseInfo?.cost(this);
+            return this.baseInfo.cost(this);
         }
 
         const baseCost = parseFloat(this.system.BASECOST) || 0;

--- a/module/item/item.mjs
+++ b/module/item/item.mjs
@@ -5668,6 +5668,7 @@ export class HeroSystem6eItem extends Item {
      *
      * PH: FIXME: This doesn't work for at least the following powers:
      * TK
+     * Anything that doesn't have a damage effect (e.g. Darkness)
      */
     damageLevelTweaking(diceParts) {
         const plusOnePipAdderData = getModifierInfo({


### PR DESCRIPTION
- stop crash
- correct point costs for 5e

NOTE: radius still doesn't work correctly for attacks (will show up with radius 0") but this can be changed in the template