### PR TITLE
Fixes #2460 - Prevent upkeep cost for COSTSENDONLYTOACTIVATE modifier

### DIFF
--- a/module/combat.mjs
+++ b/module/combat.mjs
@@ -804,7 +804,7 @@ export class HeroSystem6eCombat extends Combat {
                     item.baseInfo && // Do we have baseInfo for this power
                     item.baseInfo.duration !== "instant" && // Is the power non instant
                     ((parseInt(item.system.end || 0) > 0 && // Does the power use END?
-                        !item.system.MODIFIER?.find((o) => o.XMLID === "COSTSEND" && o.OPTION === "ACTIVATE")) || // Does the power use END continuously?
+                        !item.system.MODIFIER?.find((o) => (o.XMLID === "COSTSEND" && o.OPTION === "ACTIVATE") || o.XMLID === "COSTSENDONLYTOACTIVATE")) || // Does the power use END continuously?
                         (item.system.charges && !item.system.charges.continuing)), // Does the power use charges but is not continuous (as that is tracked by an effect when made active)?
             )) {
                 const {


### PR DESCRIPTION
Fixes #2640 

Prevents per-segment upkeep cost for COSTSENDONLYTOACTIVATE  modifier.