### PR TITLE
fix(action icons): show dice for "dice" behaviours without "to-hit"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Items with charge clips no longer get an extra clip. [#2898](https://github.com/dmdorman/hero6e-foundryvtt/issues/2898)
 - Weapon familiarity skill now displays correctly. [#2856](https://github.com/dmdorman/hero6e-foundryvtt/issues/2856)
 - Martial Arts with weapons that are not damage related (e.g. entangle, adjustment) should now work correctly. [#2814](https://github.com/dmdorman/hero6e-foundryvtt/issues/2814)
+- Show dice icon again for items that have no to-hit but have damage/effects. [#2926](https://github.com/dmdorman/hero6e-foundryvtt/issues/2926)
 
 ## Version 4.1.17 20250921
 

--- a/templates/item/item-action-icons-partial.hbs
+++ b/templates/item/item-action-icons-partial.hbs
@@ -3,18 +3,18 @@
 {{#if this.disabledOIHID}}
     <i class="fal fa-minus-square fa-xl item-oihid" title="{{localize "ActorSheet.OnlyInHeroicID"}}" width="24" height="24"></i>
 {{else}}
-{{#if (itemHasBehaviours this "roll" "success")}}
-    {{#if this.system.roll}}
-        <button type="button" class="item-rollable" data-roll="{{this.system.roll}}" data-label="{{this._id}}">
-            {{numberFormat this.system.roll decimals=0 sign=false}}-
-        </button>
-    {{else}}
-        {{log 'missing roll for ' this}}
+    {{#if (itemHasBehaviours this "roll" "success")}}
+        {{#if this.system.roll}}
+            <button type="button" class="item-rollable" data-roll="{{this.system.roll}}" data-label="{{this._id}}">
+                {{numberFormat this.system.roll decimals=0 sign=false}}-
+            </button>
+        {{else}}
+            {{log 'missing roll for ' this}}
+        {{/if}}       
     {{/if}}
-    
-{{/if}}
 
-    {{#if (itemHasActionBehavior this "to-hit")}}
+    {{!-- The dice icon does double duty - for to-hit or for damage/effects that don't require a to-hit roll (e.g. luck, unluck, susceptibility) --}}
+    {{#if (or (itemHasActionBehavior this "to-hit") (itemHasBehaviours this "dice"))}}
         <a class="item-image item-rollable"><i class="fas fa-dice" title="{{this.name}}" width="24" height="24"></i></a>
     {{/if}}
 


### PR DESCRIPTION
Resolves #2926