### PR TITLE
fix(resources): be explicit in to hit card when no resources to be used

### DIFF
--- a/module/item/item-attack.mjs
+++ b/module/item/item-attack.mjs
@@ -4373,7 +4373,7 @@ async function spendResourcesToUse(
             });
     }
 
-    let resourcesUsedDescription = "";
+    let resourcesUsedDescription = "No END Or Charges"; // Catch all for 0 END from any sources and 0 CHARGES.
     if (resourcesUsedDescriptions.length > 0) {
         // Turn array of descriptions into a single string
         if (resourcesUsedDescriptions.length === 1) {


### PR DESCRIPTION
Resolves #2981 by providing some default text for 0 END, 0 END reserve, and 0 charges required/consumed.