### PR TITLE
Requires a Roll:

### DIFF
--- a/module/item/item.mjs
+++ b/module/item/item.mjs
@@ -47,7 +47,6 @@ import { HeroAdderModel } from "./HeroSystem6eTypeDataModels.mjs";
 import { ItemVppConfig } from "../applications/apps/item-vpp-config.mjs";
 import { calculateDicePartsForItem } from "../utility/damage.mjs";
 
-
 export function initializeItemHandlebarsHelpers() {
     Handlebars.registerHelper("itemFullDescription", itemFullDescription);
     Handlebars.registerHelper("itemName", itemName);
@@ -5683,12 +5682,12 @@ export async function RequiresACharacteristicRollCheck(actor, characteristic, re
  * @param {HeroSystem6eItem} item
  * @param {Object} options
  * @returns {Boolean} - success
- * 
+ *
  * The RaR is the Requires A Roll including Activation roll from 5e.
  * If the Activation roll is a simple throw then it is quite easily done.
  * If it is connected to a Skill or Characteristic then the correct roll must be discovered.
  * There are several places a player might put information to tie the RaR to an existing skill/characteristic.
- * 
+ *
  * 1) ALIAS/Display: RaR has a Display in HD which is ALIAS here: an editable field which users are likely to change to indicate their selected roll, as it shows naturally on the sheet.
  * 2) OPTION/Options: the Options field in RaR that can also be edited.
  * 2--a ) OPTIONID/Options: the same drop-down gives and uneditable flag that indicates things like
@@ -5700,7 +5699,7 @@ export async function RequiresACharacteristicRollCheck(actor, characteristic, re
  *    - and the difficulty -1/10 (default), -1/5 (hard), -1/20 (easy)
  * 3) COMMENTS/Comments: is an editable field that users might use to indicate the roll required.
  * 4) ROLLALIAS: is a 5e only editable field that users might use to indicate the roll required.
- * 
+ *
  * the Skills to be matched will be generally be referenced as 'o' as they are considered in anonymous find functions.
  * ex: filterSkillRollItems which filters out skill items from skill enhancers and skill level bonuses.
  * Skills that are to be matched will be 'rollable' skills.
@@ -5709,13 +5708,13 @@ export async function RequiresACharacteristicRollCheck(actor, characteristic, re
  * Likewise with the Background skills (KS, PS, SS) are a special case as they can be purchased multiple times with different INPUTs.
  * The Background skills are only matched when the RaR is looking for one of those specifically.
  * The RaR will have an OPTIONID of KS, PS, or SS which must match the skill's XMLID.
- * 
+ *
  * 1) o.name/Name
  * 2) o.system.ALIAS/Display
  * 3) o.system.XMLID/XMLID
  * 4) o.system.INPUT/(Science/Knowledge/ (Background skills only)
- * 
- * 
+ *
+ *
  */
 export async function rollRequiresASkillRollCheck(item, options = {}) {
     const rar = item.modifiers.find((o) => o.XMLID === "REQUIRESASKILLROLL" || o.XMLID === "ACTIVATIONROLL");
@@ -5724,29 +5723,11 @@ export async function rollRequiresASkillRollCheck(item, options = {}) {
     }
     // todo why OPTION and not OPTIONID to look for background skills (OPTIONID can't be altered by user)
     const rarOptionIsBackground = rar.OPTION.substring(0, 2).toUpperCase();
-    console.log(`rarOptionIsBackground: ${rarOptionIsBackground} OPTION: ${rar.OPTION}  OPTIONID: ${rar.OPTIONID}`);
-
-    //TODO remove when finished
-    function logAttributes(items, filterFn, attributesToLog = []) {
-        const matches = items.filter(filterFn);
-
-        matches.forEach(item => {
-            const logData = {};
-
-            attributesToLog.forEach(attr => {
-                // allows nested paths like "system.XMLID"
-                const value = attr.split('.').reduce((obj, key) => obj?.[key], item);
-                logData[attr] = value;
-            });
-
-            console.log("Item:", item.name || "", logData);
-        });
-
-        return matches; // return matching items in case caller needs them
-    }
 
     const filterSkillRollItems = (o) => {
-        if (!o.isRollable()) { return false; }
+        if (!o.isRollable()) {
+            return false;
+        }
         return (
             o.baseInfo?.type?.includes("skill") && // is a skill
             !o.baseInfo?.type?.includes("enhancer") && // is not an enhancer (scholar, scientist, etc.)
@@ -5762,17 +5743,16 @@ export async function rollRequiresASkillRollCheck(item, options = {}) {
     };
 
     const findSkillRoll = (rar) => {
-        const rarAliasDisplay = rar.ALIAS?.toUpperCase() || "";// From the "Display" field. ex: "Requires A Magic Roll"
+        const rarAliasDisplay = rar.ALIAS?.toUpperCase() || ""; // From the "Display" field. ex: "Requires A Magic Roll"
         // OPTION_ALIAS is different in 5e: it is entered in the Type field
         const rarOptionsAlias = rar.OPTION_ALIAS?.toUpperCase() || ""; // From the "Options" field. ex: "Magic Roll, -1 per 5 Active Points modifier"
         const rarComments = rar.COMMENTS?.toUpperCase() || ""; // From Comments, begins blank, common use would be to enter just the skill name
-        const rarRollAlias = rar.ROLLALIAS?.toUpperCase() || "";// From the 5e "Roll" field. ex: "STR", "Acrobatics"
+        const rarRollAlias = rar.ROLLALIAS?.toUpperCase() || ""; // From the 5e "Roll" field. ex: "STR", "Acrobatics"
 
-        const rar_AliasDisplay = rarAliasDisplay.replaceAll(' ', "_");
-        const rar_OptionsAlias = rarOptionsAlias.replaceAll(' ', "_");
-        const rar_Comments = rarComments.replaceAll(' ', "_");
-        const rar_RollAlias = rarRollAlias.replaceAll(' ', "_");
-
+        const rar_AliasDisplay = rarAliasDisplay.replaceAll(" ", "_");
+        const rar_OptionsAlias = rarOptionsAlias.replaceAll(" ", "_");
+        const rar_Comments = rarComments.replaceAll(" ", "_");
+        const rar_RollAlias = rarRollAlias.replaceAll(" ", "_");
 
         const matchRequiredSkillRoll = (o) => {
             // TODO
@@ -5789,7 +5769,8 @@ export async function rollRequiresASkillRollCheck(item, options = {}) {
             }
             const nameUpper = o.name?.toUpperCase() ?? "";
             const nameMatch =
-                nameUpper && rarOptionIsBackground !== nameUpper &&
+                nameUpper &&
+                rarOptionIsBackground !== nameUpper &&
                 (rarAliasDisplay.includes(nameUpper) ||
                     rarOptionsAlias.includes(nameUpper) ||
                     rarRollAlias.includes(nameUpper) ||
@@ -5799,7 +5780,8 @@ export async function rollRequiresASkillRollCheck(item, options = {}) {
             }
             const aliasUpper = o.system.ALIAS?.toUpperCase() ?? "";
             const aliasMatch =
-                aliasUpper && rarOptionIsBackground !== aliasUpper &&
+                aliasUpper &&
+                rarOptionIsBackground !== aliasUpper &&
                 (rarAliasDisplay.includes(aliasUpper) ||
                     rarOptionsAlias.includes(aliasUpper) ||
                     rarRollAlias.includes(aliasUpper) ||
@@ -5819,10 +5801,10 @@ export async function rollRequiresASkillRollCheck(item, options = {}) {
                 return true;
             }
 
-            // TODO check 'Text'? 
-            // TODO check 'Type'? 
+            // TODO check 'Text'?
+            // TODO check 'Type'?
             return false;
-        }
+        };
 
         const backgroundSkillKeys = {
             // matches RaR OPTION to XMLID
@@ -5832,11 +5814,11 @@ export async function rollRequiresASkillRollCheck(item, options = {}) {
         };
 
         const isBackgroundSkillType = () => {
-            return (rar.OPTIONID === "BASICRSR") || (Object.keys(backgroundSkillKeys).includes(rarOptionIsBackground))
+            return rar.OPTIONID === "BASICRSR" || Object.keys(backgroundSkillKeys).includes(rarOptionIsBackground);
         };
 
         const matchBackgroundSkillType = (o) => {
-            return (rar.OPTIONID === "BASICRSR") || (backgroundSkillKeys[rarOptionIsBackground] === o.system.XMLID);
+            return rar.OPTIONID === "BASICRSR" || backgroundSkillKeys[rarOptionIsBackground] === o.system.XMLID;
         };
 
         const matchBackgroundSkillRoll = (o) => {
@@ -5844,11 +5826,12 @@ export async function rollRequiresASkillRollCheck(item, options = {}) {
                 return false;
             }
             const inputUpper = o.system.INPUT?.toUpperCase() ?? "";
-            const inputMatch = (
-                inputUpper && rarOptionIsBackground !== inputUpper &&
+            const inputMatch =
+                inputUpper &&
+                rarOptionIsBackground !== inputUpper &&
                 (rarAliasDisplay.includes(inputUpper) ||
                     rarOptionsAlias.includes(inputUpper) ||
-                    rarComments.includes(inputUpper)));
+                    rarComments.includes(inputUpper));
             if (inputMatch) {
                 return true;
             }
@@ -5873,14 +5856,14 @@ export async function rollRequiresASkillRollCheck(item, options = {}) {
         if (rar.OPTIONID.includes("1PER20")) {
             return 20;
         }
-        const divisorOption = rar.ADDER.find(o => {
-            return (o.XMLID === "MINUS1PER20") || (o.XMLID === "MINUS1PER5");
+        const divisorOption = rar.ADDER.find((o) => {
+            return o.XMLID === "MINUS1PER20" || o.XMLID === "MINUS1PER5";
         });
 
-        if(divisorOption?.XMLID  === "MINUS1PER20"){
+        if (divisorOption?.XMLID === "MINUS1PER20") {
             return 20;
         }
-        if(divisorOption?.XMLID  === "MINUS1PER5"){
+        if (divisorOption?.XMLID === "MINUS1PER5") {
             return 5;
         }
         // activation rolls have no minuses due to active points
@@ -5898,8 +5881,9 @@ export async function rollRequiresASkillRollCheck(item, options = {}) {
         return Math.floor(parseInt(item.activePoints) / divisor);
     };
 
-    const characteristicKeys = Object.keys(item.actor.system.characteristics)
-        .filter((k) => item.actor.system.characteristics[k].roll != null);
+    const characteristicKeys = Object.keys(item.actor.system.characteristics).filter(
+        (k) => item.actor.system.characteristics[k].roll != null,
+    );
     const rarDisplayMaybeHasCharKey = rar.ALIAS?.toLowerCase() || "";
     const rarOptionMaybeHasCharKey = rar.OPTION_ALIAS?.toLowerCase() || "";
     const rarCommentMaybeHasCharKey = rar.COMMENTS?.toLowerCase() || ""; // pre or presence, STR or Strength
@@ -5907,7 +5891,7 @@ export async function rollRequiresASkillRollCheck(item, options = {}) {
     // The \b ensures the match is at the start of a word
     const characteristicKeyRegex = characteristicKeys.reduce((accumulator, currentKey) => {
         // For each key, create the RegExp object
-        const regex = new RegExp(`\\b${currentKey}`, 'i');
+        const regex = new RegExp(`\\b${currentKey}`, "i");
         accumulator[currentKey] = regex;
         return accumulator;
     }, {});
@@ -5919,31 +5903,37 @@ export async function rollRequiresASkillRollCheck(item, options = {}) {
             return rarCommentMaybeHasCharKey;
         }
         // comment would be Strength, Intelligence, Presence etc.
-        const matchedKeyInComment = characteristicKeys.find((key) => characteristicKeyRegex[key].test(rarCommentMaybeHasCharKey));
+        const matchedKeyInComment = characteristicKeys.find((key) =>
+            characteristicKeyRegex[key].test(rarCommentMaybeHasCharKey),
+        );
         if (matchedKeyInComment) {
             return matchedKeyInComment;
         }
-        const matchedKeyInName = characteristicKeys.find((key) => characteristicKeyRegex[key].test(rarDisplayMaybeHasCharKey));
+        const matchedKeyInName = characteristicKeys.find((key) =>
+            characteristicKeyRegex[key].test(rarDisplayMaybeHasCharKey),
+        );
         if (matchedKeyInName) {
             return matchedKeyInName;
         }
-        const matchedKeyInRollAlias = characteristicKeys.find((key) => characteristicKeyRegex[key].test(rarRollAliasMaybeHasCharKey));
+        const matchedKeyInRollAlias = characteristicKeys.find((key) =>
+            characteristicKeyRegex[key].test(rarRollAliasMaybeHasCharKey),
+        );
         if (matchedKeyInRollAlias) {
             return matchedKeyInRollAlias;
         }
-        const matchedKeyInOption = characteristicKeys.find((key) => characteristicKeyRegex[key].test(rarOptionMaybeHasCharKey));
+        const matchedKeyInOption = characteristicKeys.find((key) =>
+            characteristicKeyRegex[key].test(rarOptionMaybeHasCharKey),
+        );
         return matchedKeyInOption ?? "";
     };
 
     const charKey = getRequiredCharacteristicKey();
 
     // if the RaR is an Activation roll, then we have the value we need
-    logAttributes([rar], () => true, ["parent.NAME", "ALIAS", "OPTION", "OPTION_ALIAS", "OPTIONID", "COMMENTS", "OPTION", "ROLLALIAS"]);
     let value = findRollValue(rar);
     let skill = undefined;
     let char = undefined;
     if (isNaN(value)) {
-        logAttributes(item.actor.items, filterSkillRollItems, ["name", "system.XMLID", "system.ALIAS", "system.INPUT"]);
         if (rar.OPTIONID !== "CHAR") {
             skill = findSkillRoll(rar);
         }
@@ -5957,10 +5947,9 @@ export async function rollRequiresASkillRollCheck(item, options = {}) {
                         `${item.actor.name} has a power ${item.name}, which is incorrectly built.  Skill Roll for ${charKey.toUpperCase()} should be a Characteristic Roll.`,
                     );
                 }
-            }
-            else {
+            } else {
                 // could not find a skill or characteristic to match
-                const typeOfRollRequired = (rar.OPTIONID !== "CHAR") ? "known skill" : "characteristic";
+                const typeOfRollRequired = rar.OPTIONID !== "CHAR" ? "known skill" : "characteristic";
                 ui.notifications.warn(
                     `${item.actor.name} has a power ${item.name}. Expecting '${rar.OPTION} roll', where ${rar.OPTION} is the name of a ${typeOfRollRequired} that can be rolled.
                     <br>Put the name of the ${typeOfRollRequired} into the Options or Comments of the Requires A Roll modifier for the best results.`,
@@ -5997,7 +5986,7 @@ export async function rollRequiresASkillRollCheck(item, options = {}) {
     const usefulAlias = rarOptionIsBackground !== skill?.system.ALIAS ? skill?.system.ALIAS : "";
     const skillName = skill?.system.INPUT || usefulAlias || skill?.name;
     const charName = charKey?.toUpperCase();
-    const activationFrom = (skill) ? `${skillName}:` : ((char) ? `${charName}:` : "");
+    const activationFrom = skill ? `${skillName}:` : char ? `${charName}:` : "";
     if (skill?.system.XMLID === "LUCK") {
         const { diceParts } = calculateDicePartsForItem(skill, {});
 
@@ -6008,30 +5997,26 @@ export async function rollRequiresASkillRollCheck(item, options = {}) {
             .addHalfDice(diceParts.halfDieCount >= 1 ? diceParts.halfDieCount : 0)
             .addDiceMinus1(diceParts.d6Less1DieCount >= 1 ? diceParts.d6Less1DieCount : 0)
             .addNumber(diceParts.constant);
+
         await roller.roll();
-        console.log("Luck Roll:", roller);
-        console.log("Luck Roll EffectTerms:", roller.getEffectTerms());
-        console.log("Luck Roll EffectTotal:", roller.getEffectTotal());
 
         const lucky = roller.getEffectTerms();
-        console.log(`flavor ${item.name} (${activationFrom}${lucky})`);
-        // Each “6” rolled counts as 1 point of Luck. 
+        // Each “6” rolled counts as 1 point of Luck.
         const luck = lucky.reduce((accumulator, dieRoll) => {
-            if (dieRoll === 6) { accumulator += 1; }
+            if (dieRoll === 6) {
+                accumulator += 1;
+            }
             return accumulator;
         }, 0);
-        if(rar.OPTIONID === "ONELUCK"){
+        if (rar.OPTIONID === "ONELUCK") {
             succeeded = luck >= 1;
-        }
-        else if(rar.OPTIONID === "TWOLUCK"){
+        } else if (rar.OPTIONID === "TWOLUCK") {
             succeeded = luck >= 2;
-        }
-        else if(rar.OPTIONID === "THREELUCK"){
+        } else if (rar.OPTIONID === "THREELUCK") {
             succeeded = luck >= 3;
         }
         flavor = `${item.name} (${activationFrom} rolled ${lucky} for ${luck} points) activation ${succeeded ? "succeeded" : "failed"} `;
-    }
-    else {
+    } else {
         if (skill) {
             // skill.system.roll is a string
             value = parseInt(skill.system.roll);
@@ -6043,9 +6028,7 @@ export async function rollRequiresASkillRollCheck(item, options = {}) {
             // a char.roll is an int
             value = char.roll;
         } else if (!value) {
-            ui.notifications.warn(
-                `${item.actor.name} has a power ${item.name}. ${rar.OPTION_ALIAS} is not supported.`,
-            );
+            ui.notifications.warn(`${item.actor.name} has a power ${item.name}. ${rar.OPTION_ALIAS} is not supported.`);
             // Try to continue
             value = 11;
         }
@@ -6061,19 +6044,17 @@ export async function rollRequiresASkillRollCheck(item, options = {}) {
         const total = roller.getSuccessTotal();
         const margin = successValue - total;
 
-        const targetRoll = (skill) ? skill.system.roll : ((char) ? char.roll : `${rar.OPTION_ALIAS}:${value}-`);
+        const targetRoll = skill ? skill.system.roll : char ? char.roll : `${rar.OPTION_ALIAS}:${value}-`;
         const divisor = findRollDivisor(rar);
-        const penalty = (isNaN(divisor) ? "" : `, -1 per ${divisor} active points`)
+        const penalty = isNaN(divisor) ? "" : `, -1 per ${divisor} active points`;
 
-        const penaltyString = (penalty) ? `${penalty}: -${minus}` : "";
+        const penaltyString = penalty ? `${penalty}: -${minus}` : "";
 
-        console.log(`flavor ${item.name} (${activationFrom}${targetRoll}${penaltyString})`);
-
-        flavor = `${item.name} (${activationFrom}${targetRoll}${penaltyString}) activation ${succeeded ? "succeeded" : "failed"
-            } by ${autoSuccess === undefined ? `${Math.abs(margin)}` : `rolling ${total}`}`;
+        flavor = `${item.name} (${activationFrom}${targetRoll}${penaltyString}) activation ${
+            succeeded ? "succeeded" : "failed"
+        } by ${autoSuccess === undefined ? `${Math.abs(margin)}` : `rolling ${total}`}`;
     }
     cardHtml = await roller.render(flavor);
-
 
     // FORCE success
     if (!succeeded && overrideCanAct) {
@@ -6104,7 +6085,6 @@ export async function rollRequiresASkillRollCheck(item, options = {}) {
     if (!succeeded && options.showUi) {
         ui.notifications.warn(cardHtml);
     }
-
     return succeeded;
 }
 


### PR DESCRIPTION
Fixed skills now uses display name, and background skills Organized and expanded the Requires a Roll code
Supports common use cases
The code still looks in Options and Comments,
but now will also look at the Display Name
to find the appropriate skill or stat to roll
 combining with ROLLALIAS