### PR TITLE
bugfix(deactivation-of-charge-powers): Prevent toggle on HDC upload of charge powers [#3068]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Version 4.2.3 20251109 So far...
+
+- Resolves charge powers not showing up in the attack tab after HDC upload. [#3068](https://github.com/dmdorman/hero6e-foundryvtt/issues/3068)
+
 ## Version 4.2.2 20251108 [Hero System 6e (Unofficial) v2](https://github.com/dmdorman/hero6e-foundryvtt)
 
 - Various VPP improvements, including the ability to choose VPP slots. Exceeding VPP pool is not enforced. [#2743](https://github.com/dmdorman/hero6e-foundryvtt/issues/2743) [#2869](https://github.com/dmdorman/hero6e-foundryvtt/issues/2869)

--- a/module/item/item.mjs
+++ b/module/item/item.mjs
@@ -796,9 +796,6 @@ export class HeroSystem6eItem extends Item {
                 ["system.charges.value"]: this.system.charges.max,
                 ["system.charges.clips"]: this.system.charges.clipsMax,
             });
-            if (this.isActive) {
-                await this.toggle();
-            }
         }
 
         if (this.system.XMLID === "ENDURANCERESERVE" && this.system.value !== this.system.LEVELS) {


### PR DESCRIPTION
Removes regression added in [bf2a7062](https://github.com/dmdorman/hero6e-foundryvtt/commit/bf2a70628cba1b59736ab21f590f4828ac8705c5). Cursory regression testing shows no further issues on charge powers on upload

Closes #3068 