### PR TITLE
bugfix(template-tag-hdc): Correctly handle explicit TEMPLATE tags in HDC files

### DIFF
--- a/module/actor/actor.mjs
+++ b/module/actor/actor.mjs
@@ -2053,7 +2053,10 @@ export class HeroSystem6eActor extends Actor {
             uploadProgressBar.advance(`${this.name}: is5e`, 0);
             let _is5e = true;
 
-            const template = heroJson.CHARACTER?.TEMPLATE || heroJson.CHARACTER?.BASIC_CONFIGURATION?.TEMPLATE;
+            const template =
+                heroJson.CHARACTER?.TEMPLATE?.extends ||
+                heroJson.CHARACTER?.TEMPLATE ||
+                heroJson.CHARACTER?.BASIC_CONFIGURATION?.TEMPLATE;
 
             if (typeof template === "string") {
                 if (template.includes("builtIn.") && !template.includes("6E.")) {


### PR DESCRIPTION
Closes #3139 

Allows for uploading HDC files with explicit template tags.

Test instructions:
1. Upload an actor with a legacy TEMPLATE xml tag defined. The attached issue has a minimal example.
2. Upload another actor with a more modern/standard XML schema.
3. Both should succeed.

(I'll move this into Quench a bit later today)