### PR TITLE
fix(compendium): add missing awaits and make unlocking consistent

### DIFF
--- a/module/heroCompendiums.mjs
+++ b/module/heroCompendiums.mjs
@@ -7,8 +7,8 @@ export async function CreateHeroCompendiums() {
     if (!game.user.isGM) return;
 
     try {
-        CreateHeroItems();
-        CreateHeroMacros();
+        await CreateHeroItems();
+        await CreateHeroMacros();
     } catch (e) {
         console.error(e);
     }
@@ -35,6 +35,11 @@ async function CreateHeroMacros() {
         await pack.deleteCompendium();
     }
     pack = await FoundryVttCompendiumCollection.createCompendium(metadata);
+
+    // V13 seems to default new compendiums to locked
+    if (pack.locked) {
+        await pack.configure({ locked: false });
+    }
 
     const macroItemsArray = [];
 


### PR DESCRIPTION
Sometimes the compeniums are reported as locked when migrating. Fix a few mistakes:
* missing awaits that probably don't affect anything other than allow other things to start running before creating compendia is complete
* make unlocking of new hero Macro compendium after creation consistent with the Items compendium (i.e. have both create)