### PR TITLE
fix(actor-sheet-v2): Fix character art edit on v2 actor sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Turning on (or carrying) items with ACTIVATIONROLL or that are used EVERYPHASE no longer consume resources during item toggle. This is meant to resolve issues with ARMORs that should not consume resources to put on, but do consume resources when the defense is used as part of an attack. [#1751](https://github.com/dmdorman/hero6e-foundryvtt/issues/1751)
 - Initial support for sectional defenses. Put "locations x-y" in the comments for ACTIVATIONROLL or REQUIRESAROLL. More complicated locations are not yet supported. REQUIRESAROLL also requires the "Must be made each Phase/use" adder. [#3876](https://github.com/dmdorman/hero6e-foundryvtt/issues/3876) [#1652](https://github.com/dmdorman/hero6e-foundryvtt/issues/1652)
 - Fix ability to edit OPTION_ALIAS of 6e Penalty Skill Levels. [#3964](https://github.com/dmdorman/hero6e-foundryvtt/issues/3964)
+- Fix ActorSheetV2 not persisting changes to character image. [#3962](https://github.com/dmdorman/hero6e-foundryvtt/issues/3962)
 
 ### Version 4.3.0 20260322
 

--- a/module/applications/actor/actor-sheet-v2.mjs
+++ b/module/applications/actor/actor-sheet-v2.mjs
@@ -55,6 +55,7 @@ export class HeroSystemActorSheetV2 extends HandlebarsApplicationMixin(ActorShee
             toggleEffect: HeroSystemActorSheetV2.#onToggleEffect,
             toggleItemContainer: HeroSystemActorSheetV2.#onToggleItemContainer,
             toggleStatus: HeroSystemActorSheetV2.#onToggleStatus,
+            updateActorImage: HeroSystemActorSheetV2.#onUpdateActorImage,
             vpp: HeroSystemActorSheetV2.#onVpp,
         },
         //tag: "form", // The default is "div"
@@ -1556,6 +1557,30 @@ export class HeroSystemActorSheetV2 extends HandlebarsApplicationMixin(ActorShee
         await this.actor.toggleStatusEffect(status);
     }
 
+    /**
+     * Handle changing a Document's image.
+     * @param {MouseEvent} event  The click event.
+     * @returns {Promise<FilePicker>}
+     * @protected
+     */
+    static async #onUpdateActorImage(event, target) {
+        const attr = target.dataset.edit;
+        const current = foundry.utils.getProperty(this.object, attr);
+        const { img } = this.document.constructor.getDefaultArtwork?.(this.document.toObject()) ?? {};
+        const fp = new FilePicker.implementation({
+            current,
+            type: "image",
+            redirectToRoot: img ? [img] : [],
+            callback: async (path) => {
+                // Potential improvement: If we want to manage token here or separately (see DND5e sheet for potential inspiration on UI), path is 'tokenPrototype.texture.src'
+                await this.document.update({ img: path });
+            },
+            top: this.position.top + 40,
+            left: this.position.left + 10,
+        });
+        return fp.browse();
+    }
+
     #heroValidationCssForTab(items) {
         if (!items || items.length === 0) {
             return "";
@@ -1730,28 +1755,4 @@ export class HeroSystemActorSheetV2 extends HandlebarsApplicationMixin(ActorShee
     // get dragDrop() {
     //     return this.#dragDrop;
     // }
-
-    /**
-     * Handle changing a Document's image.
-     * @param {MouseEvent} event  The click event.
-     * @returns {Promise<FilePicker>}
-     * @protected
-     */
-    _onEditImage(event) {
-        const attr = event.currentTarget.dataset.edit;
-        const current = foundry.utils.getProperty(this.object, attr);
-        const { img } = this.document.constructor.getDefaultArtwork?.(this.document.toObject()) ?? {};
-        const fp = new FilePicker.implementation({
-            current,
-            type: "image",
-            redirectToRoot: img ? [img] : [],
-            callback: (path) => {
-                event.currentTarget.src = path;
-                if (this.options.submitOnChange) return this._onSubmit(event);
-            },
-            top: this.position.top + 40,
-            left: this.position.left + 10,
-        });
-        return fp.browse();
-    }
 }

--- a/templates/actor/actor-sheet-v2-parts/actor-sheet-aside-v2.hbs
+++ b/templates/actor/actor-sheet-v2-parts/actor-sheet-aside-v2.hbs
@@ -3,7 +3,7 @@
         <img class="profile-img {{#if (getScopedFlagValue actor @root/gameSystemId "uploading")}}uploading-blur{{/if}}" 
             src="{{actor.img}}" 
             data-edit="img" 
-            data-action="{{#if actor.isOwner}}editImage{{/if}}"
+            data-action="{{#if actor.isOwner}}updateActorImage{{/if}}"
             title="{{actor.name}}" height="100"
             width="100" 
         />


### PR DESCRIPTION
Builtin `editImage` action requires submitOnChange to be set, leading to failure to persist changes to the image on ActorSheetV2. This bypasses editImage to instead update the attribute on filepicker set.

The solution of setting submitOnChange to be true was considered, but causes validation errors. Fixing these validation errors requires some unpleasant code and also causes frequent refreshing of the entire sheet, with all the UI flashing that comes with that. This implementation is marginally more seamless. However, the alternate implementation is visible at https://github.com/ndguarino/hero6e-foundryvtt/tree/fix/actor-sheet-v2/editImage for validation.

This adds a new action, and does a slight bit of code reformatting to put the newly static method closer to the other static methods defined in actions.

Fixes #3962 