### PR TITLE
fix(system.json): fix download and manifest links to stop FoundryVTT error

### DIFF
--- a/system.json
+++ b/system.json
@@ -56,8 +56,8 @@
     "primaryTokenAttribute": "characteristics.body",
     "secondaryTokenAttribute": "characteristics.stun",
     "url": "https://github.com/dmdorman/hero6e-foundryvtt",
-    "manifest": "https://github.com/dmdorman/hero6e-foundryvtt/releases/download/<RELEASE>/system.json",
-    "download": "https://github.com/dmdorman/hero6e-foundryvtt/releases/download/<RELEASE>/hero6efoundryvttv2.zip",
+    "manifest": "https://github.com/dmdorman/hero6e-foundryvtt/releases/latest/download/system.json",
+    "download": "https://github.com/dmdorman/hero6e-foundryvtt/releases/latest/download/hero6efoundryvttv2.zip",
     "license": "https://raw.githubusercontent.com/dmdorman/hero6e-foundryvtt/main/LICENSE.txt",
     "changelog": "https://github.com/dmdorman/hero6e-foundryvtt/blob/main/CHANGELOG.md",
     "bugs": "https://github.com/dmdorman/hero6e-foundryvtt/issues"


### PR DESCRIPTION
Resolves #3947

Other systems don't bother providing a specific link for each version so this ought to be good enough.