### PR TITLE
Fixes #4358 - Implement manual targeting for AOE and regions for any/surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Improved compendium prefab support. Improved and drag/drop support of items.
 - Fix crashes with NND maneuvers. [#4326](https://github.com/dmdorman/hero6e-foundryvtt/issues/4326)
+- Added support for ANY and Surface AOEs (Foundry V14 only) [#4358](https://github.com/dmdorman/hero6e-foundryvtt/issues/4358)
+- Added support for overriding AOE templates with manual targeting [#4358](https://github.com/dmdorman/hero6e-foundryvtt/issues/4358)
 
 ### Version 4.3.11 20260621
 

--- a/module/applications/item/item-attack-application-v2.mjs
+++ b/module/applications/item/item-attack-application-v2.mjs
@@ -641,6 +641,8 @@ export class ItemAttackFormApplicationV2 extends HandlebarsApplicationMixin(Appl
 
         const templateType = heroAoeTypeToFoundryAoeTypeConversions[aoeType];
 
+        const isFreeform = aoeType === "any" || aoeType === "surface";
+
         //const sizeConversionToMeters = convertSystemUnitsToMetres(1, actor.is5e);
 
         //const hexTemplates = game.settings.get(HEROSYS.module, "HexTemplates");
@@ -687,48 +689,82 @@ export class ItemAttackFormApplicationV2 extends HandlebarsApplicationMixin(Appl
             "restriction.priority": 0,
         };
 
-        switch (templateType) {
-            case "circle":
-                {
-                    regionData.shapes[0].radius = metersToPixels(areaOfEffect.value) / 2;
-                }
-                break;
-
-            case "cone":
-                {
-                    if ((areaOfEffect.ADDER || []).find((adder) => adder.XMLID === "THINCONE")) {
-                        regionData.shapes[0].angle = 30;
-                    } else {
-                        regionData.shapes[0].angle = 60;
+        if (isFreeform) {
+            // Build shapes directly: the conversion map's "rect" is not a real Region shape type, and
+            // placeRegion lets the player place each shape in turn (right-click to stop early).
+            const grid = canvas.grid;
+            const areaCount = Math.max(1, areaOfEffect.value || 1);
+            let makeAreaShape;
+            if (!actor.is5e) {
+                const oneAreaRadius = metersToPixels(2) / 2;
+                makeAreaShape = () => ({
+                    type: "circle",
+                    x: token.center.x,
+                    y: token.center.y,
+                    radius: oneAreaRadius,
+                });
+            } else if (grid.isGridless) {
+                // Gridless can't snap to a cell, so approximate each area as a circle.
+                const oneAreaRadius = metersToPixels(1) / 2;
+                makeAreaShape = () => ({
+                    type: "circle",
+                    x: token.center.x,
+                    y: token.center.y,
+                    radius: oneAreaRadius,
+                });
+            } else {
+                // A 1x1 token-base emanation snaps to a single grid cell.
+                const tokenShape = grid.isHexagonal ? CONST.TOKEN_SHAPES.ELLIPSE_1 : CONST.TOKEN_SHAPES.RECTANGLE_1;
+                makeAreaShape = () => ({
+                    type: "emanation",
+                    radius: 0,
+                    base: {
+                        type: "token",
+                        x: token.document.x,
+                        y: token.document.y,
+                        width: 1,
+                        height: 1,
+                        shape: tokenShape,
+                    },
+                });
+            }
+            regionData.shapes = Array.from({ length: areaCount }, makeAreaShape);
+            ui.notifications.info(
+                `Place up to ${areaCount} ${actor.is5e ? "hex(es)" : "2m area(s)"}: left-click to place each, right-click to stop early.`,
+            );
+        } else {
+            switch (templateType) {
+                case "circle":
+                    {
+                        regionData.shapes[0].radius = metersToPixels(areaOfEffect.value) / 2;
                     }
-                    regionData.shapes[0].radius = metersToPixels(areaOfEffect.value) / 2;
-                }
+                    break;
 
-                break;
+                case "cone":
+                    {
+                        if ((areaOfEffect.ADDER || []).find((adder) => adder.XMLID === "THINCONE")) {
+                            regionData.shapes[0].angle = 30;
+                        } else {
+                            regionData.shapes[0].angle = 60;
+                        }
+                        regionData.shapes[0].radius = metersToPixels(areaOfEffect.value) / 2;
+                    }
 
-            case "line":
-                {
-                    // width & length are in pixels
-                    // AARON: Not sure why we are dividing by 2 here.
-                    regionData.shapes[0].width = metersToPixels(areaOfEffect.width) / 2;
-                    regionData.shapes[0].length = metersToPixels(areaOfEffect.value) / 2;
-                }
-                break;
+                    break;
 
-            // case "rect": {
-            //     // if (areaOfEffect.type === "surface" && item.findModsByXmlid("CONTINUOUS")) {
-            //     //     // This is likely a damage shield
-            //     // }
+                case "line":
+                    {
+                        // width & length are in pixels
+                        // AARON: Not sure why we are dividing by 2 here.
+                        regionData.shapes[0].width = metersToPixels(areaOfEffect.width) / 2;
+                        regionData.shapes[0].length = metersToPixels(areaOfEffect.value) / 2;
+                    }
+                    break;
 
-            //     // rectangle templates are defined as a distance/hypotenuse and an angle
-            //     regionData.direction = areaOfEffect.direction;
-            //     regionData.distance = sizeConversionToMeters * areaOfEffect.distance;
-            //     break;
-            // }
-
-            default:
-                console.error(`unsupported template type ${templateType}`);
-                break;
+                default:
+                    console.error(`unsupported template type ${templateType}`);
+                    break;
+            }
         }
 
         const existingTemplate = this.getAoeTemplate();

--- a/module/applications/item/item-attack-application-v2.mjs
+++ b/module/applications/item/item-attack-application-v2.mjs
@@ -502,6 +502,13 @@ export class ItemAttackFormApplicationV2 extends HandlebarsApplicationMixin(Appl
                 this.data.aoeText += ` (${levels}${getSystemDisplayUnits(this.data.effectiveItem.actor.is5e)})`;
             }
 
+            this.data.aoeFreeform = aoe.type === "any" || aoe.type === "surface";
+            if (this.data.aoeFreeform) {
+                this.data.aoeAllowedCount = this.data.effectiveItem.actor.is5e
+                    ? `${levels} hex(es)`
+                    : `${levels} 2m area(s)`;
+            }
+
             // if (this.getAoeTemplate() || game.user.targets.size > 0) {
             //     this.data.noTargets = false;
             // } else {
@@ -528,6 +535,12 @@ export class ItemAttackFormApplicationV2 extends HandlebarsApplicationMixin(Appl
                         `No area of effect template found for this attack. Please place the template before rolling the attack.`,
                     );
                 }
+                await this.close();
+                return processActionToHit(this.data.effectiveItem, extendedFormData, { token: this.data.token });
+            }
+
+            case "rollManualTarget": {
+                extendedFormData.aoeManualTargeting = true;
                 await this.close();
                 return processActionToHit(this.data.effectiveItem, extendedFormData, { token: this.data.token });
             }

--- a/module/item/item-attack-application.mjs
+++ b/module/item/item-attack-application.mjs
@@ -495,6 +495,13 @@ export class ItemAttackFormApplication extends FormApplication {
                 this.data.aoeText += ` (${levels}${getSystemDisplayUnits(this.data.effectiveItem.actor.is5e)})`;
             }
 
+            this.data.aoeFreeform = aoe.type === "any" || aoe.type === "surface";
+            if (this.data.aoeFreeform) {
+                this.data.aoeAllowedCount = this.data.effectiveItem.actor.is5e
+                    ? `${levels} hex(es)`
+                    : `${levels} 2m area(s)`;
+            }
+
             if (this.getAoeTemplate() || game.user.targets.size > 0) {
                 this.data.noTargets = false;
             } else {
@@ -654,6 +661,14 @@ export class ItemAttackFormApplication extends FormApplication {
         this.#setAoeAndHitLocationDataForEffectiveItem();
 
         if (event.submitter?.name === "roll") {
+            canvas.tokens.activate();
+            await this.close();
+
+            return processActionToHit(this.data.effectiveItem, formData, { token: this.data.token });
+        }
+
+        if (event.submitter?.name === "rollManualTarget") {
+            formData.aoeManualTargeting = true;
             canvas.tokens.activate();
             await this.close();
 

--- a/module/item/item-attack-application.mjs
+++ b/module/item/item-attack-application.mjs
@@ -782,6 +782,14 @@ export class ItemAttackFormApplication extends FormApplication {
         const aoeType = areaOfEffect.type;
         const aoeValue = areaOfEffect.value;
 
+        // TODO: Remove when V13 support is dropped. Freeform shapes need drawable Regions (V14+); the V13
+        // MeasuredTemplate path can't represent them, so refuse cleanly rather than throwing.
+        if (aoeType === "any" || aoeType === "surface") {
+            return ui.notifications.warn(
+                `Placing a template for a "${aoeType}" Area Of Effect is not supported in this version of Foundry. Use "Use manual token targeting (skip template)" instead.`,
+            );
+        }
+
         const actor = item.actor;
         const token = actor.getActiveTokens()[0] || canvas.tokens.controlled[0];
         if (!token) {

--- a/module/item/item-attack.mjs
+++ b/module/item/item-attack.mjs
@@ -359,8 +359,8 @@ export async function processActionToHit(item, formData, options = {}) {
 
     // PH: FIXME: Need to not pass in formData and move the interesting stuff into action
 
-    // Does the effective attack item have an AoE?
-    if (item.effectiveAttackItem.getAoeModifier()) {
+    // Manual targeting resolves an AoE per-target via the single-target path, not the origin roll.
+    if (item.effectiveAttackItem.getAoeModifier() && !formData.aoeManualTargeting) {
         await doAoeActionToHit(action, formData, options);
     } else {
         await doSingleTargetActionToHit(action, formData, options);
@@ -929,8 +929,10 @@ async function doSingleTargetActionToHit(action, options) {
     }
 
     const isAoE = item.effectiveAttackItem.getAoeModifier();
-    const aoeTemplate = isAoE ? item.getAoeTemplateForBaseItem : null;
-    if (isAoE && !aoeTemplate) {
+    // Manual targeting has no placed template; resolve against the selected tokens, not an origin.
+    const manualAoeTargeting = !!isAoE && !!options.aoeManualTargeting;
+    const aoeTemplate = isAoE && !manualAoeTargeting ? item.getAoeTemplateForBaseItem : null;
+    if (isAoE && !manualAoeTargeting && !aoeTemplate) {
         return ui.notifications.error(`Attack AOE template was not found.`);
     }
 
@@ -975,7 +977,8 @@ async function doSingleTargetActionToHit(action, options) {
         ? aoeModifier.ADDER.find((o) => o.XMLID === "NONSELECTIVETARGET")
         : null;
 
-    const aoeAlwaysHit = aoeModifier && !(SELECTIVETARGET || NONSELECTIVETARGET);
+    // Manual targeting rolls to-hit per target instead of auto-hitting everything in the area.
+    const aoeAlwaysHit = aoeModifier && !manualAoeTargeting && !(SELECTIVETARGET || NONSELECTIVETARGET);
 
     let targetData = [];
     const targetIds = [];
@@ -985,8 +988,8 @@ async function doSingleTargetActionToHit(action, options) {
         targetsArray = canvas.tokens.controlled;
     }
 
-    // If AOE then sort by distance from center
-    if (explosion) {
+    // Sort by distance from the template origin (absent under manual targeting).
+    if (explosion && aoeTemplate) {
         targetsArray.sort(function (a, b) {
             const distanceA = calculateDistanceBetween(aoeTemplate, a).distance;
             const distanceB = calculateDistanceBetween(aoeTemplate, b).distance;
@@ -1054,7 +1057,7 @@ async function doSingleTargetActionToHit(action, options) {
 
         // Pick the appropriate target based on the attack type. For AoE it's the base of the AoE template for
         // a single target attack it's the actual target.
-        const targetForDistance = isAoE ? aoeTemplate : target;
+        const targetForDistance = isAoE && aoeTemplate ? aoeTemplate : target;
         const distance = token ? calculateDistanceBetween(token, targetForDistance).distance : 0;
 
         // Range modifiers

--- a/templates/attack/item-attack-application-v2.hbs
+++ b/templates/attack/item-attack-application-v2.hbs
@@ -419,6 +419,12 @@
       <button class="aoe-button" type="submit" name="aoe">
         Place {{aoeText}} template
       </button>
+      <button class="aoe-button" type="submit" name="rollManualTarget">
+        Use manual token targeting (skip template)
+      </button>
+      {{#if aoeFreeform}}
+        <p class="notes">Covers up to {{aoeAllowedCount}}; areas/tokens must be contiguous.</p>
+      {{/if}}
     {{/if}}
 
     {{#if action.maneuver.isMultipleAttackManeuver}}

--- a/templates/attack/item-attack-application.hbs
+++ b/templates/attack/item-attack-application.hbs
@@ -413,6 +413,12 @@
       <button class="aoe-button" type="submit" name="aoe">
         Place {{aoeText}} template
       </button>
+      <button class="aoe-button" type="submit" name="rollManualTarget">
+        Use manual token targeting (skip template)
+      </button>
+      {{#if aoeFreeform}}
+        <p class="notes">Covers up to {{aoeAllowedCount}}; areas/tokens must be contiguous.</p>
+      {{/if}}
     {{/if}}
 
     {{#if action.maneuver.isMultipleAttackManeuver}}


### PR DESCRIPTION
Fixes #4358 

1. Allows for manual targeting with AOE shapes
2. For V14, implement freeform regions for any and surface shapes. 5e, use single hex; 6e, use 2m spheres.
3. V13, redirect user to manual targeting for template placement rather than throwing an unhelpful error.