### PR TITLE
V2 Multiple Attack Dialog - Multiple Issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,15 @@
 ### Version 4.3.11 so far... [Hero System 6e (Unofficial) v2](https://github.com/dmdorman/hero6e-foundryvtt)
 
 - Improved compendium prefab support. Improved and drag/drop support of items.
+<<<<<<< HEAD
 - Fix crashes with NND maneuvers. [#4326](https://github.com/dmdorman/hero6e-foundryvtt/issues/4326)
 - Added support for overriding AOE templates with manual targeting [#4358](https://github.com/dmdorman/hero6e-foundryvtt/issues/4358)
+=======
+- Fixed dangling hooks in multiple attack dialog (V1 and V2) [#3785](https://github.com/dmdorman/hero6e-foundryvtt/issues/3785)
+- Fixed attacks not appearing in V2 Multiple Attack Dialog [#4318](https://github.com/dmdorman/hero6e-foundryvtt/issues/4318)
+- Fixed endurance for remaining attacks not being consumed (V2 Only) [#3785](https://github.com/dmdorman/hero6e-foundryvtt/issues/3785)
+- Introduces a clarity improvement for the V2 multiple attack dialog's buttons.
+>>>>>>> 36aa065c (changelog)
 
 ### Version 4.3.11 20260621
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Improved compendium prefab support. Improved and drag/drop support of items.
 - Fix crashes with NND maneuvers. [#4326](https://github.com/dmdorman/hero6e-foundryvtt/issues/4326)
-- Added support for ANY and Surface AOEs (Foundry V14 only) [#4358](https://github.com/dmdorman/hero6e-foundryvtt/issues/4358)
 - Added support for overriding AOE templates with manual targeting [#4358](https://github.com/dmdorman/hero6e-foundryvtt/issues/4358)
 
 ### Version 4.3.11 20260621

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,8 @@
 ### Version 4.3.11 so far... [Hero System 6e (Unofficial) v2](https://github.com/dmdorman/hero6e-foundryvtt)
 
 - Improved compendium prefab support. Improved and drag/drop support of items.
-<<<<<<< HEAD
 - Fix crashes with NND maneuvers. [#4326](https://github.com/dmdorman/hero6e-foundryvtt/issues/4326)
 - Added support for overriding AOE templates with manual targeting [#4358](https://github.com/dmdorman/hero6e-foundryvtt/issues/4358)
-=======
-- Fixed dangling hooks in multiple attack dialog (V1 and V2) [#3785](https://github.com/dmdorman/hero6e-foundryvtt/issues/3785)
-- Fixed attacks not appearing in V2 Multiple Attack Dialog [#4318](https://github.com/dmdorman/hero6e-foundryvtt/issues/4318)
-- Fixed endurance for remaining attacks not being consumed (V2 Only) [#3785](https://github.com/dmdorman/hero6e-foundryvtt/issues/3785)
-- Introduces a clarity improvement for the V2 multiple attack dialog's buttons.
->>>>>>> 36aa065c (changelog)
 
 ### Version 4.3.11 20260621
 

--- a/module/applications/item/item-attack-application-v2.mjs
+++ b/module/applications/item/item-attack-application-v2.mjs
@@ -564,8 +564,9 @@ export class ItemAttackFormApplicationV2 extends HandlebarsApplicationMixin(Appl
             }
 
             case "continueMultiattack":
+                this.data.formData ??= {};
                 this.data.formData.continueMultiattack = true;
-                break;
+                return this.render();
 
             case "executeMultiattack":
                 {

--- a/module/applications/item/item-attack-application-v2.mjs
+++ b/module/applications/item/item-attack-application-v2.mjs
@@ -1,7 +1,12 @@
 // REF: https://foundryvtt.wiki/en/development/api/applicationv2
 import { HEROSYS } from "../../herosystem6e.mjs";
 import { filterIgnoreCompoundAndFrameworkItems } from "../../config.mjs";
-import { calculateRequiredResourcesToUse, dehydrateAttackItem, processActionToHit } from "../../item/item-attack.mjs";
+import {
+    calculateRequiredResourcesToUse,
+    dehydrateAttackItem,
+    processActionToHit,
+    userInteractiveVerifyOptionallyPromptThenSpendResources,
+} from "../../item/item-attack.mjs";
 import { buildEffectiveObject } from "../../item/item.mjs";
 import { Attack } from "../../utility/attack.mjs";
 import {
@@ -611,7 +616,7 @@ export class ItemAttackFormApplicationV2 extends HandlebarsApplicationMixin(Appl
                 break;
 
             case "missedMultiattack":
-                // TODO: charge user the end cost for the remaining attacks
+                await this.#forfeitRemainingMultiattackEndurance();
                 canvas.tokens.activate();
                 await this.close();
                 return;
@@ -1175,6 +1180,48 @@ export class ItemAttackFormApplicationV2 extends HandlebarsApplicationMixin(Appl
         const multipleAttackKey = target.dataset.multiattack;
         if (Attack.removeMultipleAttack(this.data, multipleAttackKey)) {
             this.render();
+        }
+    }
+
+    async #forfeitRemainingMultiattackEndurance() {
+        const attackKeys = this.data.action?.maneuver?.attackKeys;
+        const remainingStart = this.data.formData?.execute;
+        const actor = this.data.actor;
+        if (!attackKeys?.length || remainingStart === undefined || !actor) {
+            return;
+        }
+
+        const descriptions = [];
+        for (let i = remainingStart; i < attackKeys.length; i++) {
+            const attackItem = actor.items.get(attackKeys[i].itemKey);
+            if (!attackItem) {
+                continue;
+            }
+
+            const { error, warning, resourcesUsedDescription } =
+                await userInteractiveVerifyOptionallyPromptThenSpendResources(attackItem, {
+                    ...this.data.formData,
+                    token: this.data.token,
+                });
+
+            if (error) {
+                ui.notifications.error(`${attackItem.name} ${error}`);
+            } else if (warning) {
+                ui.notifications.warn(`${attackItem.name} ${warning}`);
+            } else if (resourcesUsedDescription) {
+                descriptions.push(`${attackItem.name}: ${resourcesUsedDescription}`);
+            }
+        }
+
+        if (descriptions.length) {
+            await ChatMessage.create({
+                author: game.user.id,
+                style: CONST.CHAT_MESSAGE_STYLES.OTHER,
+                speaker: ChatMessage.getSpeaker({ actor, token: this.data.token }),
+                content: `<b>${actor.name}</b> forfeits END for the remaining attacks of a missed multiple attack:<ul><li>${descriptions.join(
+                    "</li><li>",
+                )}</li></ul>`,
+            });
         }
     }
 }

--- a/module/applications/item/item-attack-application-v2.mjs
+++ b/module/applications/item/item-attack-application-v2.mjs
@@ -97,6 +97,10 @@ export class ItemAttackFormApplicationV2 extends HandlebarsApplicationMixin(Appl
             handler: ItemAttackFormApplicationV2.#onSubmit,
             closeOnSubmit: false,
         },
+        actions: {
+            addMultiattack: ItemAttackFormApplicationV2.#onAddAttackToMultipleAttackManeuver,
+            removeMultiattack: ItemAttackFormApplicationV2.#onRemoveAttackFromMultipleAttackManeuver,
+        },
         window: {
             icon: "fas fa-swords",
         },
@@ -1145,5 +1149,18 @@ export class ItemAttackFormApplicationV2 extends HandlebarsApplicationMixin(Appl
                 return this._onChange.call(this, ev, new FormDataExtended(this.element));
             });
         });
+    }
+
+    static async #onAddAttackToMultipleAttackManeuver() {
+        if (Attack.addMultipleAttack(this.data)) {
+            this.render();
+        }
+    }
+
+    static async #onRemoveAttackFromMultipleAttackManeuver(event, target) {
+        const multipleAttackKey = target.dataset.multiattack;
+        if (Attack.removeMultipleAttack(this.data, multipleAttackKey)) {
+            this.render();
+        }
     }
 }

--- a/module/applications/item/item-attack-application-v2.mjs
+++ b/module/applications/item/item-attack-application-v2.mjs
@@ -56,15 +56,28 @@ export class ItemAttackFormApplicationV2 extends HandlebarsApplicationMixin(Appl
 
     data;
 
+    #hookIds = {};
+
     constructor(data) {
         super();
         this.data = data;
 
-        Hooks.on("targetToken", ItemAttackFormApplicationV2.#targetTokenHandler.bind(this));
-        Hooks.on("controlToken", ItemAttackFormApplicationV2.#controlTokenHandler.bind(this));
+        this.#hookIds.targetToken = Hooks.on("targetToken", ItemAttackFormApplicationV2.#targetTokenHandler.bind(this));
+        this.#hookIds.controlToken = Hooks.on(
+            "controlToken",
+            ItemAttackFormApplicationV2.#controlTokenHandler.bind(this),
+        );
 
         // If  CSLs change on the Actor we need to know
-        Hooks.on("updateItem", ItemAttackFormApplicationV2.#updateItemHandler.bind(this));
+        this.#hookIds.updateItem = Hooks.on("updateItem", ItemAttackFormApplicationV2.#updateItemHandler.bind(this));
+    }
+
+    _onClose(options) {
+        super._onClose(options);
+
+        Hooks.off("targetToken", this.#hookIds.targetToken);
+        Hooks.off("controlToken", this.#hookIds.controlToken);
+        Hooks.off("updateItem", this.#hookIds.updateItem);
     }
 
     static async #targetTokenHandler() {
@@ -591,7 +604,7 @@ export class ItemAttackFormApplicationV2 extends HandlebarsApplicationMixin(Appl
                         canvas.tokens.activate();
                         await this.close();
                     } else {
-                        return await new ItemAttackFormApplicationV2(this.data).render(true);
+                        return this.render();
                     }
                 }
 

--- a/module/applications/item/item-attack-application-v2.mjs
+++ b/module/applications/item/item-attack-application-v2.mjs
@@ -431,6 +431,20 @@ export class ItemAttackFormApplicationV2 extends HandlebarsApplicationMixin(Appl
                 { ...this.data.formData, token: this.data.token }, // use formData to include player options from the form
             );
 
+            const manueverItem = this.data.effectiveItem;
+            this.data.multiAttackItems ??= this.data.action.maneuver.isMultipleAttackManeuver
+                ? this.data.originalItem.actor.items.filter(filterIgnoreCompoundAndFrameworkItems).filter((item) => {
+                      return (
+                          (item.baseInfo.type.includes("attack") ||
+                              (item.baseInfo.type.includes("maneuver") && item.rollsToHit())) && // Is an attack, or an offensive (to-hit) maneuver?
+                          (manueverItem.system.XMLID === "MULTIPLEATTACK" || // 6e Multipleattack allows both HTH and Ranged
+                              (manueverItem.system.XMLID === "SWEEP" && item.isHth) || // 5e Sweep is HTH only
+                              (manueverItem.system.XMLID === "RAPIDFIRE" && item.isRanged)) && // 5e Rapid Fire is Ranged only
+                          !item.system.XMLID.startsWith("__") // No internal placeholder powers/items
+                      );
+                  })
+                : [];
+
             // the title seems to be fixed when the form is initialized,
             // and doesn't change afterwards even if we come through here again
             // todo: figure out how to adjust the title when we want it to

--- a/module/item/item-attack-application.mjs
+++ b/module/item/item-attack-application.mjs
@@ -29,6 +29,8 @@ const heroAoeTypeToFoundryAoeTypeConversions = Object.freeze({
 });
 
 export class ItemAttackFormApplication extends FormApplication {
+    #hookIds = {};
+
     constructor(data) {
         super();
         this.data = data;
@@ -39,14 +41,14 @@ export class ItemAttackFormApplication extends FormApplication {
             // to properly wait for promises to resolve before refreshing the UI.
             window.setTimeout(() => this.refresh(), 1);
         };
-        Hooks.on("targetToken", _targetToken.bind(this));
+        this.#hookIds.targetToken = Hooks.on("targetToken", _targetToken.bind(this));
 
         const _controlToken = async function () {
             // Necessary for situations where it is not possible
             // to properly wait for promises to resolve before refreshing the UI.
             window.setTimeout(() => this.refresh(), 1);
         };
-        Hooks.on("controlToken", _controlToken.bind(this));
+        this.#hookIds.controlToken = Hooks.on("controlToken", _controlToken.bind(this));
 
         // If  CSLs change on the Actor we need to know
         const _updateItem = async function (item) {
@@ -55,7 +57,15 @@ export class ItemAttackFormApplication extends FormApplication {
                 this.refresh();
             }
         };
-        Hooks.on("updateItem", _updateItem.bind(this));
+        this.#hookIds.updateItem = Hooks.on("updateItem", _updateItem.bind(this));
+    }
+
+    async close(options) {
+        Hooks.off("targetToken", this.#hookIds.targetToken);
+        Hooks.off("controlToken", this.#hookIds.controlToken);
+        Hooks.off("updateItem", this.#hookIds.updateItem);
+
+        return super.close(options);
     }
 
     refresh() {
@@ -701,7 +711,7 @@ export class ItemAttackFormApplication extends FormApplication {
                 canvas.tokens.activate();
                 await this.close();
             } else {
-                return await new ItemAttackFormApplication(this.data).render(true);
+                return this.render();
             }
         } else if (event.submitter?.name === "missedMultiattack") {
             // TODO: charge user the end cost for the remaining attacks

--- a/module/item/item-attack.mjs
+++ b/module/item/item-attack.mjs
@@ -1274,6 +1274,7 @@ async function doSingleTargetActionToHit(action, options) {
         flags: {
             [game.system.id]: {
                 ...cardData,
+                token: cardData.token.document.toObject(),
             },
         },
     };

--- a/module/item/item.mjs
+++ b/module/item/item.mjs
@@ -1312,10 +1312,13 @@ export class HeroSystem6eItem extends HeroObjectCacheMixin(Item) {
                 case "MINDSCAN":
                 case "MOVEBY":
                 case "MOVETHROUGH":
+                case "MULTIPLEATTACK":
+                case "RAPIDFIRE":
                 case "RKA":
                 case "SET":
                 case "STRIKE":
                 case "SUCCOR":
+                case "SWEEP":
                 case "TELEKINESIS":
                 case "TRANSFER":
                 case "TRANSFORM":
@@ -1335,17 +1338,14 @@ export class HeroSystem6eItem extends HeroObjectCacheMixin(Item) {
                 case "GRABBY":
                 case "HIPSHOT":
                 case "HURRY":
-                case "MULTIPLEATTACK":
                 case "OTHERATTACKS":
                 case "PULLINGAPUNCH":
-                case "RAPIDFIRE":
                 case "ROLLWITHAPUNCH":
                 case "SETANDBRACE":
                 case "SHOVE":
                 case "SNAPSHOT":
                 case "STRAFE":
                 case "SUPPRESSIONFIRE":
-                case "SWEEP":
                 case "THROW":
                 case "TRIP":
                 default:

--- a/scss/components/_item-attack.scss
+++ b/scss/components/_item-attack.scss
@@ -31,4 +31,28 @@
         background: var(--input-background-color);
         color: var(--input-text-color);
     }
+
+    .multi-attack-options.target-container {
+        display: grid;
+        grid-template-columns: 8fr 8fr 1fr;
+        align-items: center;
+        width: 100%;
+        text-align: center;
+    }
+
+    .target-info-header,
+    .target-info-row {
+        display: contents;
+    }
+
+    .target-info-row .target-name {
+        text-align: left;
+        width: 100%;
+    }
+
+    .target-info-row label {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
 }

--- a/scss/components/_item-attack.scss
+++ b/scss/components/_item-attack.scss
@@ -54,5 +54,25 @@
         display: flex;
         align-items: center;
         justify-content: center;
+
+        .fas {
+            cursor: pointer;
+
+            &.disabled {
+                cursor: default;
+                opacity: 0.3;
+                pointer-events: none;
+            }
+        }
+    }
+
+    .add-attack-row {
+        .add-attack-spacer {
+            visibility: hidden;
+        }
+
+        label {
+            grid-column: 3;
+        }
     }
 }

--- a/templates/attack/item-attack-application-v2.hbs
+++ b/templates/attack/item-attack-application-v2.hbs
@@ -54,14 +54,24 @@
                 {{/each}}
               </select>
               <label>
-                {{#if (eq index 0)}}
-                  <span class="fas fa-plus {{#unless @root/action.current.missed}}add-multiattack{{/unless}}" {{#unless @root/action.current.missed}}data-action="addMultiattack"{{/unless}} > </span>
+                {{#if (or @root/action.current.missed (eq @root/action.maneuver.attackKeys.length 1))}}
+                  <span class="fas fa-trash disabled" ></span>
                 {{else}}
-                  <span class="fas fa-trash {{#unless @root/action.current.missed}}remove-multiattack{{/unless}}" {{#unless @root/action.current.missed}}data-action="removeMultiattack"{{/unless}} data-multiattack="{{multiAttack.attackKey}}" ></span>
+                  <span class="fas fa-trash remove-multiattack" data-action="removeMultiattack" data-multiattack="{{multiAttack.attackKey}}" ></span>
                 {{/if}}
               </label>
             </div>
           {{/each}}
+          <div class="target-info-row add-attack-row">
+            <select class="add-attack-spacer" tabindex="-1" aria-hidden="true" disabled></select>
+            <label>
+              {{#if @root/action.current.missed}}
+                <span class="fas fa-plus disabled" ></span>
+              {{else}}
+                <span class="fas fa-plus add-multiattack" data-action="addMultiattack" ></span>
+              {{/if}}
+            </label>
+          </div>
         </div>
       </div>
       <div {{#unless action.current.cvMod.cvMod.ocv }}style="display: none;"{{/unless}}>

--- a/templates/attack/item-attack-application-v2.hbs
+++ b/templates/attack/item-attack-application-v2.hbs
@@ -55,9 +55,9 @@
               </select>
               <label>
                 {{#if (eq index 0)}}
-                  <span class="fas fa-plus {{#unless @root/action.current.missed}}add-multiattack{{/unless}}" > </span>
+                  <span class="fas fa-plus {{#unless @root/action.current.missed}}add-multiattack{{/unless}}" {{#unless @root/action.current.missed}}data-action="addMultiattack"{{/unless}} > </span>
                 {{else}}
-                  <span class="fas fa-trash {{#unless @root/action.current.missed}}remove-multiattack{{/unless}}" data-multiattack="{{multiAttack.attackKey}}" ></span>
+                  <span class="fas fa-trash {{#unless @root/action.current.missed}}remove-multiattack{{/unless}}" {{#unless @root/action.current.missed}}data-action="removeMultiattack"{{/unless}} data-multiattack="{{multiAttack.attackKey}}" ></span>
                 {{/if}}
               </label>
             </div>


### PR DESCRIPTION
Fixes #4318 
Relates to #3785 

* Fixes missing attacks in V2 multiple attack dialog
* Adds endurance consumption for remaining attacks
* Fixes failure on "continue anyway" action
* Cleans up application hooks, preventing errors on retarget during and after application close
* Removes an application rebuild in favour of a rerender
* Slight improvement to UI/UX for clarity in multiple attack dialog