### PR TITLE
feat(multi-attack): honor STR/HTH on sub-attacks (V2)

### DIFF
--- a/module/applications/item/item-attack-application-v2.mjs
+++ b/module/applications/item/item-attack-application-v2.mjs
@@ -1246,12 +1246,12 @@ export class ItemAttackFormApplicationV2 extends HandlebarsApplicationMixin(Appl
 
         const descriptions = [];
         for (let i = remainingStart; i < attackKeys.length; i++) {
-            const rawItem = actor.items.get(attackKeys[i].itemKey);
-            if (!rawItem) {
+            const originalItem = actor.items.get(attackKeys[i].itemKey);
+            if (!originalItem) {
                 continue;
             }
 
-            const attackItem = await this.#buildEffectiveObjectForSubItem(rawItem);
+            const attackItem = await this.#buildEffectiveObjectForSubItem(originalItem);
             const { error, warning, resourcesUsedDescription } =
                 await userInteractiveVerifyOptionallyPromptThenSpendResources(attackItem, {
                     ...this.data.formData,
@@ -1259,11 +1259,11 @@ export class ItemAttackFormApplicationV2 extends HandlebarsApplicationMixin(Appl
                 });
 
             if (error) {
-                ui.notifications.error(`${rawItem.name} ${error}`);
+                ui.notifications.error(`${originalItem.name} ${error}`);
             } else if (warning) {
-                ui.notifications.warn(`${rawItem.name} ${warning}`);
+                ui.notifications.warn(`${originalItem.name} ${warning}`);
             } else if (resourcesUsedDescription) {
-                descriptions.push(`${rawItem.name}: ${resourcesUsedDescription}`);
+                descriptions.push(`${originalItem.name}: ${resourcesUsedDescription}`);
             }
         }
 

--- a/module/applications/item/item-attack-application-v2.mjs
+++ b/module/applications/item/item-attack-application-v2.mjs
@@ -334,31 +334,46 @@ export class ItemAttackFormApplicationV2 extends HandlebarsApplicationMixin(Appl
                 this.data.originalItem.system.conditionalAttacks[DEADLYBLOW.id].system.checked ??= true;
             }
 
+            // During the execute phase of a multiple attack, the per-step sub-attack (e.g. a Strike)
+            // drives the strength and hand-to-hand options, not the orchestrating maneuver.
+            const multiAttackExecute = this.data.formData?.execute;
+            const isMultipleAttackManeuver = ["MULTIPLEATTACK", "SWEEP", "RAPIDFIRE"].includes(
+                this.data.originalItem.system.XMLID,
+            );
+            this.data.multiAttackSubItem =
+                isMultipleAttackManeuver && multiAttackExecute !== undefined
+                    ? (this.data.originalItem.actor.items.get(this.data.formData[`attack-${multiAttackExecute}`]) ??
+                      null)
+                    : null;
+            const hthBaseItem = this.data.multiAttackSubItem ?? this.data.originalItem;
+
             // Hand-to-hand attacks only apply to things that are strength damage based
-            if (isManeuverThatDoesNormalDamage(this.data.originalItem)) {
-                const hthAttacks = this.data.originalItem.actor.items.filter(
+            if (isManeuverThatDoesNormalDamage(hthBaseItem)) {
+                const hthAttacks = hthBaseItem.actor.items.filter(
                     (item) => item.system.XMLID === "HANDTOHANDATTACK" && !(item.system.CARRIED && !item.system.active),
                 );
-                this.data.hthAttackItems ??= hthAttacks.reduce((attacksObj, hthAttack) => {
-                    // If already exists we're updating so no need to recreate.
-                    // ItemAttackFormApplication uses uuid as key, which confuses foundry.expandObject because
-                    // the key contains periods. Instead of fixup code we are simplifying by using just the id,
-                    // which is unique.
-                    if (attacksObj[hthAttack.id]) {
-                        return attacksObj;
-                    }
 
-                    attacksObj[hthAttack.id] = {
-                        _canUseForAttack: false,
-                        reasonForCantUse: "",
-                        description: hthAttack.system.description,
-                        name: hthAttack.name,
-                        uuid: hthAttack.uuid,
-                    };
-                    return attacksObj;
-                }, {});
+                // Rebuild when the base item changes (e.g. advancing to a different sub-attack); otherwise
+                // keep the existing entries so the user's selections persist across renders.
+                if (this.data._hthAttackItemsForItemId !== hthBaseItem.id) {
+                    this.data._hthAttackItemsForItemId = hthBaseItem.id;
+                    this.data.hthAttackItems = hthAttacks.reduce((attacksObj, hthAttack) => {
+                        // ItemAttackFormApplication uses uuid as key, which confuses foundry.expandObject because
+                        // the key contains periods. Instead of fixup code we are simplifying by using just the id,
+                        // which is unique.
+                        attacksObj[hthAttack.id] = {
+                            _canUseForAttack: false,
+                            reasonForCantUse: "",
+                            description: hthAttack.system.description,
+                            name: hthAttack.name,
+                            uuid: hthAttack.uuid,
+                        };
+                        return attacksObj;
+                    }, {});
+                }
             } else {
                 this.data.hthAttackItems = {};
+                this.data._hthAttackItemsForItemId = null;
             }
 
             // Weapons can be used with HTH or ranged martial maneuvers. The user needs to have Weapon Element.
@@ -447,10 +462,19 @@ export class ItemAttackFormApplicationV2 extends HandlebarsApplicationMixin(Appl
 
             this.#setAoeAndHitLocationDataForEffectiveItem();
 
+            this.data.effectiveSubItems = {};
+            this.data.multiAttackCurrentItem = null;
+            if (this.data.multiAttackSubItem) {
+                const effectiveSubItem = await this.#buildEffectiveObjectForSubItem(this.data.multiAttackSubItem);
+                this.data.effectiveSubItems[`attack-${multiAttackExecute}`] = effectiveSubItem;
+                this.data.multiAttackCurrentItem = effectiveSubItem;
+            }
+
             this.data.action = Attack.buildActionInfo(
                 this.data.effectiveItem,
                 this.data.targets,
-                { ...this.data.formData, token: this.data.token }, // use formData to include player options from the form
+                // use formData to include player options from the form
+                { ...this.data.formData, token: this.data.token, effectiveSubItems: this.data.effectiveSubItems },
             );
 
             const manueverItem = this.data.effectiveItem;
@@ -598,7 +622,9 @@ export class ItemAttackFormApplicationV2 extends HandlebarsApplicationMixin(Appl
                         // TODO: if any roll misses, the multiattack ends, and the end cost for the remainding attacks are forfeit
 
                         // this is the roll:
-                        await processActionToHit(this.data.effectiveItem, this.data.formData);
+                        await processActionToHit(this.data.effectiveItem, this.data.formData, {
+                            effectiveSubItems: this.data.effectiveSubItems,
+                        });
 
                         this.data.formData.execute = this.data.action.current.execute + 1;
                     }
@@ -930,6 +956,12 @@ export class ItemAttackFormApplicationV2 extends HandlebarsApplicationMixin(Appl
 
     // Create a new effectiveItem
     async #buildEffectiveObjectFromOriginalAndData() {
+        // Hand-to-hand attacks belong to the per-step sub-attack, not the orchestrating multiple
+        // attack maneuver (which doesn't use STR), so don't apply them to the maneuver's own build.
+        const isMultipleAttackManeuver = ["MULTIPLEATTACK", "SWEEP", "RAPIDFIRE"].includes(
+            this.data.originalItem.system.XMLID,
+        );
+
         const effectiveObjectParameters = {
             originalItem: this.data.originalItem,
             effectiveRealCost: this.data.effectiveRealCost,
@@ -938,7 +970,7 @@ export class ItemAttackFormApplicationV2 extends HandlebarsApplicationMixin(Appl
             effectiveStrPushedRealPoints: this.data.effectiveStrPushedRealPoints,
 
             maWeaponId: this.data.maSelectedWeaponId,
-            hthAttackItems: this.data.hthAttackItems,
+            hthAttackItems: isMultipleAttackManeuver ? {} : this.data.hthAttackItems,
             nakedAdvantagesItems: this.data.nakedAdvantagesItems,
 
             autofire: {
@@ -948,6 +980,27 @@ export class ItemAttackFormApplicationV2 extends HandlebarsApplicationMixin(Appl
         };
 
         return buildEffectiveObject(effectiveObjectParameters);
+    }
+
+    // Build an effective item for one sub-attack of a multiple attack, applying the shared strength
+    // and hand-to-hand selections so to-hit, damage, and END reflect them.
+    async #buildEffectiveObjectForSubItem(subItem) {
+        return buildEffectiveObject({
+            originalItem: subItem,
+            effectiveRealCost: subItem._realCost,
+            pushedRealPoints: 0,
+            effectiveStr: this.data.effectiveStr,
+            effectiveStrPushedRealPoints: this.data.effectiveStrPushedRealPoints,
+
+            maWeaponId: null,
+            hthAttackItems: this.data.hthAttackItems,
+            nakedAdvantagesItems: {},
+
+            autofire: {
+                shots: 1,
+                maxShots: 1,
+            },
+        });
     }
 
     // PH: FIXME: Effective item is not STR for maneuvers with empty fist or the weapon for weapon maneuvers
@@ -1193,11 +1246,12 @@ export class ItemAttackFormApplicationV2 extends HandlebarsApplicationMixin(Appl
 
         const descriptions = [];
         for (let i = remainingStart; i < attackKeys.length; i++) {
-            const attackItem = actor.items.get(attackKeys[i].itemKey);
-            if (!attackItem) {
+            const rawItem = actor.items.get(attackKeys[i].itemKey);
+            if (!rawItem) {
                 continue;
             }
 
+            const attackItem = await this.#buildEffectiveObjectForSubItem(rawItem);
             const { error, warning, resourcesUsedDescription } =
                 await userInteractiveVerifyOptionallyPromptThenSpendResources(attackItem, {
                     ...this.data.formData,
@@ -1205,11 +1259,11 @@ export class ItemAttackFormApplicationV2 extends HandlebarsApplicationMixin(Appl
                 });
 
             if (error) {
-                ui.notifications.error(`${attackItem.name} ${error}`);
+                ui.notifications.error(`${rawItem.name} ${error}`);
             } else if (warning) {
-                ui.notifications.warn(`${attackItem.name} ${warning}`);
+                ui.notifications.warn(`${rawItem.name} ${warning}`);
             } else if (resourcesUsedDescription) {
-                descriptions.push(`${attackItem.name}: ${resourcesUsedDescription}`);
+                descriptions.push(`${rawItem.name}: ${resourcesUsedDescription}`);
             }
         }
 

--- a/module/utility/attack.mjs
+++ b/module/utility/attack.mjs
@@ -395,7 +395,9 @@ export class Attack {
             }
             const attackKey = `attack-${execute}`;
             const attackKeys = maneuver[attackKey];
-            const maneuverItem = system.attackerToken.actor.items.get(attackKeys.itemKey);
+            const maneuverItem =
+                options.effectiveSubItems?.[attackKey] ??
+                system.attackerToken.actor.items.get(attackKeys.itemKey);
             const maneuverTarget = system.targetedTokens.find((token) => token.id === attackKeys.targetKey);
             const current = this.buildManeuverInfo(maneuverItem, [maneuverTarget], options, system);
             current.execute = execute;

--- a/module/utility/attack.mjs
+++ b/module/utility/attack.mjs
@@ -396,8 +396,7 @@ export class Attack {
             const attackKey = `attack-${execute}`;
             const attackKeys = maneuver[attackKey];
             const maneuverItem =
-                options.effectiveSubItems?.[attackKey] ??
-                system.attackerToken.actor.items.get(attackKeys.itemKey);
+                options.effectiveSubItems?.[attackKey] ?? system.attackerToken.actor.items.get(attackKeys.itemKey);
             const maneuverTarget = system.targetedTokens.find((token) => token.id === attackKeys.targetKey);
             const current = this.buildManeuverInfo(maneuverItem, [maneuverTarget], options, system);
             current.execute = execute;

--- a/templates/attack/item-attack-application-v2.hbs
+++ b/templates/attack/item-attack-application-v2.hbs
@@ -208,7 +208,7 @@
         </div>
       {{/if}}
 
-      {{#if (or effectiveItem.system.usesStrength effectiveItem.system.usesTk)}}
+      {{#if (or effectiveItem.system.usesStrength effectiveItem.system.usesTk multiAttackCurrentItem.system.usesStrength multiAttackCurrentItem.system.usesTk)}}
         <div class="form-group">
           <label>Effective Strength</label>
           <div class="noflexwrap">


### PR DESCRIPTION
Partial #3785

Build each multiple-attack sub-attack as an effective item carrying the shared effectiveStr/HTH, and use it as the maneuver's currentItem so to-hit, damage, and forfeited END reflect the choices. Surface the STR and HTH controls during the execute phase, driven by the sub-attack rather than the orchestrating maneuver.