### PR TITLE
Quench fixes

### DIFF
--- a/module/testing/quench-helper.mjs
+++ b/module/testing/quench-helper.mjs
@@ -130,6 +130,26 @@ export function registerGlobalTeardown(quench) {
     );
 }
 
+/**
+ * Wait until a Token's canvas placeable has finished drawing.
+ *
+ * @param {TokenDocument} tokenDoc The token document whose placeable should be drawn.
+ * @param {number} timeoutMs How long to wait before giving up.
+ * @returns {Promise<Token|null>} The drawn token placeable, or whatever object is available on timeout.
+ */
+export async function waitForTokenDrawn(tokenDoc, timeoutMs = 5000) {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+        const obj = tokenDoc.object ?? canvas.tokens?.get(tokenDoc.id);
+        // targetArrows is created at the end of Token#_draw(), so its presence means drawing finished.
+        if (obj?.targetArrows) {
+            return obj;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    return tokenDoc.object ?? canvas.tokens?.get(tokenDoc.id) ?? null;
+}
+
 export async function waitForElementInChat(elementSelector, timeoutMs = 1000) {
     let messageHookId;
 

--- a/module/testing/testing-combat-workflow.mjs
+++ b/module/testing/testing-combat-workflow.mjs
@@ -1,4 +1,4 @@
-import { waitForElementInChat } from "./quench-helper.mjs";
+import { waitForElementInChat, waitForTokenDrawn } from "./quench-helper.mjs";
 
 export function registerCombatWorkflowTests(quench) {
     quench.registerBatch(
@@ -19,6 +19,11 @@ export function registerCombatWorkflowTests(quench) {
                     activeScene = game.scenes.active ?? game.scenes.contents?.[0];
                     if (!activeScene) {
                         activeScene = await Scene.create({ name: "Test Arena", grid: { distance: 1, units: "m" } });
+                    }
+
+                    // Ensure the scene is the one rendered on the canvas so created tokens get drawn,
+                    // otherwise their placeables never finish _draw() and targeting them throws.
+                    if (canvas.scene?.id !== activeScene.id) {
                         await activeScene.view();
                     }
 
@@ -64,7 +69,11 @@ export function registerCombatWorkflowTests(quench) {
 
                     // Simulate Targeting
                     game.user.targets.clear();
-                    const targetTokenObject = defenderTokenDoc.object || canvas.tokens?.get(defenderTokenDoc.id);
+
+                    // Wait for the token placeable to finish drawing before targeting it. Targeting starts the
+                    // target-animation ticker (Token#_drawTargetArrows), which needs the targetArrows graphics
+                    // created at the end of Token#_draw(); targeting too early throws on targetArrows.clear().
+                    const targetTokenObject = await waitForTokenDrawn(defenderTokenDoc);
 
                     if (targetTokenObject) {
                         game.user.targets.add(targetTokenObject);

--- a/module/utility/defense.mjs
+++ b/module/utility/defense.mjs
@@ -421,7 +421,7 @@ export async function getConditionalDefenses(token, item, avad) {
     conditionalDefenses.push(...vulnerabilities);
 
     // PH: FIXME: avad is either AVAD or NND. This should done correctly and not kludged as the avad parameter presently is.
-    const nndLikeDefense = avad.INPUT ?? avad.COMMENTS ?? "";
+    const nndLikeDefense = avad?.INPUT ?? avad?.COMMENTS ?? "";
     const nndLikeDefenseKey = nndLikeDefense.trim().toUpperCase();
 
     // AVAD Life Support


### PR DESCRIPTION
Fixes #4369 
Fixes #4371 

* Adds a helper to wait for draw to prevent race on targeting
* Adds null safety to AVLD defense check