### PR TITLE
fix(stun-from-end-card): Remove blind on private whisper chat card

### DIFF
--- a/module/actor/actor.mjs
+++ b/module/actor/actor.mjs
@@ -546,7 +546,6 @@ export class HeroSystem6eActor extends HeroObjectCacheMixin(Actor) {
                 author: game.user.id,
                 whisper: whisperUserTargetsForActor(this),
                 speaker: ChatMessage.getSpeaker({ actor: this }),
-                blind: true,
                 content: content,
             };
 


### PR DESCRIPTION
Fixes #4356

Blind makes this a GM blind roll, meaning only the GM can see the result. Whisper already keeps this private between the actor's owners and the GM, so this is unnecessary.