### PR TITLE
migration(chatmessage): Clean up bloated data from maneuvers in chat messages

### DIFF
--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -343,6 +343,16 @@ export async function migrateWorld() {
         async (actor) => await removePlaceholderWeaponItem(actor),
     );
 
+    // Strip the recursive self-embedded maneuver dehydration from existing chat messages (see cbbbb44).
+    // Only chat messages created before that fix carry the bloat; the fix stops new ones from getting it.
+    await migrateToVersion(
+        "4.3.15",
+        lastMigration,
+        Array.from(game.messages),
+        "reclaiming space from bloated chat messages",
+        async (message) => await removeDehydratedManeuverItemFromMessage_4_3_15(message),
+    );
+
     // Placeholder for notifying GM of items missing XMLID
     // await migrateToVersion(
     //     game.system.version,
@@ -425,6 +435,61 @@ async function commitItemsCollectionMigrateDataChanges(item) {
         const { system, flags, type } = item.toObject();
         delete flags[game.system.id][needToPersistToDb];
         await item.update({ "==system": system, "==flags": flags, type: type });
+    }
+}
+
+/**
+ * Recursively remove every `dehydratedManeuverItem` flag from a value, descending into arrays,
+ * plain objects, and JSON-string-encoded blobs (dehydrated items are stored as JSON strings, and
+ * one dehydrated item can nest another inside its effect flags).
+ */
+function stripDehydratedManeuverItem_4_3_15(value) {
+    if (typeof value === "string") {
+        // Cheap guard - only pay for JSON.parse when the marker is actually present.
+        if (!value.includes("dehydratedManeuverItem")) {
+            return value;
+        }
+
+        try {
+            return JSON.stringify(stripDehydratedManeuverItem_4_3_15(JSON.parse(value)));
+        } catch {
+            // Not a JSON string (e.g. rendered HTML content), leave it untouched.
+            return value;
+        }
+    }
+
+    if (Array.isArray(value)) {
+        return value.map((entry) => stripDehydratedManeuverItem_4_3_15(entry));
+    }
+
+    if (value && typeof value === "object") {
+        const cleaned = {};
+        for (const [key, entry] of Object.entries(value)) {
+            if (key === "dehydratedManeuverItem") {
+                continue;
+            }
+            cleaned[key] = stripDehydratedManeuverItem_4_3_15(entry);
+        }
+        return cleaned;
+    }
+
+    return value;
+}
+
+async function removeDehydratedManeuverItemFromMessage_4_3_15(message) {
+    try {
+        const originalFlags = message.toObject().flags;
+
+        // Nothing to do unless this message actually carries the bloat.
+        if (!JSON.stringify(originalFlags ?? {}).includes("dehydratedManeuverItem")) {
+            return;
+        }
+
+        const cleanedFlags = stripDehydratedManeuverItem_4_3_15(originalFlags);
+
+        await message.update({ flags: cleanedFlags });
+    } catch (e) {
+        console.error(`Failed to clean dehydratedManeuverItem from chat message ${message?.id}`, e);
     }
 }
 

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -443,28 +443,28 @@ async function commitItemsCollectionMigrateDataChanges(item) {
  * plain objects, and JSON-string-encoded blobs (dehydrated items are stored as JSON strings, and
  * one dehydrated item can nest another inside its effect flags).
  */
-function stripDehydratedManeuverItem_4_3_15(value) {
-    if (typeof value === "string") {
+function stripDehydratedManeuverItem_4_3_15(messageDataFragment) {
+    if (typeof messageDataFragment === "string") {
         // Cheap guard - only pay for JSON.parse when the marker is actually present.
-        if (!value.includes("dehydratedManeuverItem")) {
-            return value;
+        if (!messageDataFragment.includes("dehydratedManeuverItem")) {
+            return messageDataFragment;
         }
 
         try {
-            return JSON.stringify(stripDehydratedManeuverItem_4_3_15(JSON.parse(value)));
+            return JSON.stringify(stripDehydratedManeuverItem_4_3_15(JSON.parse(messageDataFragment)));
         } catch {
             // Not a JSON string (e.g. rendered HTML content), leave it untouched.
-            return value;
+            return messageDataFragment;
         }
     }
 
-    if (Array.isArray(value)) {
-        return value.map((entry) => stripDehydratedManeuverItem_4_3_15(entry));
+    if (Array.isArray(messageDataFragment)) {
+        return messageDataFragment.map((entry) => stripDehydratedManeuverItem_4_3_15(entry));
     }
 
-    if (value && typeof value === "object") {
+    if (messageDataFragment && typeof messageDataFragment === "object") {
         const cleaned = {};
-        for (const [key, entry] of Object.entries(value)) {
+        for (const [key, entry] of Object.entries(messageDataFragment)) {
             if (key === "dehydratedManeuverItem") {
                 continue;
             }
@@ -473,7 +473,7 @@ function stripDehydratedManeuverItem_4_3_15(value) {
         return cleaned;
     }
 
-    return value;
+    return messageDataFragment;
 }
 
 async function removeDehydratedManeuverItemFromMessage_4_3_15(message) {


### PR DESCRIPTION
Fixes #4395 

Adds a migration to strip existing chat messages of recursively-added dehydrated maneuver items, per cbbbb44.

Validation:
1) Load system on 4.3.14
2) Check size of bloat (see scripts below)
3) Shut down world/foundry
4) Set system to 4.3.15
5) Start world, run migration
6) Validate bloat is removed

<details><summary>Check bloat (js, run in console)</summary>
<p>

```js
(() => {
  const SYS = game.system.id;
  const bytes = (s) => new Blob([s]).size;

  // Mirror of dehydrateItemSource's cleanup: drop every `dehydratedManeuverItem`
  // key at any nesting depth, including inside JSON-string-encoded blobs.
  function clean(value) {
    if (typeof value === "string") {
      if (!value.includes("dehydratedManeuverItem")) return value;
      try {
        return JSON.stringify(clean(JSON.parse(value)));
      } catch {
        return value; // not JSON, leave as-is
      }
    }
    if (Array.isArray(value)) return value.map(clean);
    if (value && typeof value === "object") {
      const out = {};
      for (const [k, v] of Object.entries(value)) {
        if (k === "dehydratedManeuverItem") continue; // this is the bloat
        out[k] = clean(v);
      }
      return out;
    }
    return value;
  }

  let totalBefore = 0, totalAfter = 0, affected = 0, worst = 0, worstId = null;

  for (const msg of game.messages) {
    const src = msg.toObject();
    const before = bytes(JSON.stringify(src));
    const after = bytes(JSON.stringify(clean(src)));
    totalBefore += before;
    totalAfter += after;
    if (after < before) {
      affected++;
      const saved = before - after;
      if (saved > worst) { worst = saved; worstId = msg.id; }
    }
  }

  const saved = totalBefore - totalAfter;
  const MB = (n) => (n / 1024 / 1024).toFixed(2) + " MB";
  console.log("=== dehydratedManeuverItem cleanup estimate ===");
  console.log(`Total messages:        ${game.messages.size}`);
  console.log(`Messages with bloat:   ${affected}`);
  console.log(`Current message size:  ${MB(totalBefore)}`);
  console.log(`After cleanup:         ${MB(totalAfter)}`);
  console.log(`Would reclaim:         ${MB(saved)}  (${(saved / Math.max(totalBefore,1) * 100).toFixed(1)}%)`);
  console.log(`Largest single saving: ${MB(worst)}  (message ${worstId})`);
})();
```

Example output:
```
=== dehydratedManeuverItem cleanup estimate ===
VM857:46 Total messages:        1001
VM857:47 Messages with bloat:   8
VM857:48 Current message size:  106.61 MB
VM857:49 After cleanup:         80.06 MB
VM857:50 Would reclaim:         26.55 MB  (24.9%)
VM857:51 Largest single saving: 18.70 MB  (message RFDdOwMP0BdXmIAe)
```

</p>
</details> 

<details><summary>Create bloat (js, run in console)_</summary>
<p>

```js
(async () => {
    const SID = game.system.id;
    const COUNT = 5; // how many broken messages to create
    const NEST_DEPTH = 3; // recursion levels (geometric size growth, like the real bug)
    const PAD = 40000; // filler chars per item, to make the bloat visible

    // Build a dehydrated-item-shaped object whose effect flags carry a nested
    // dehydratedManeuverItem, `depth` levels deep — mirrors dehydrateAttackItem's
    // output before the fix, where each (re)serialization re-embedded the item.
    function buildDehydratedItem(depth) {
        const systemFlags = { XMLID: "MARTIALSTRIKE" };

        // Each level embeds a full dehydrated item as a JSON *string*, exactly
        // as dehydrateAttackItem stored it on the effect.
        if (depth > 0) {
            systemFlags.dehydratedManeuverItem = JSON.stringify(buildDehydratedItem(depth - 1));
        }

        return {
            item: {
                _id: foundry.utils.randomID(),
                name: "Martial Strike",
                type: "martialart",
                system: { description: "x".repeat(PAD) },
                effects: [
                    {
                        _id: foundry.utils.randomID(),
                        name: "Maneuver Active Effect",
                        flags: { [SID]: systemFlags },
                    },
                ],
            },
        };
    }

    const itemJsonStr = JSON.stringify(buildDehydratedItem(NEST_DEPTH));

    // actionData double-escapes currentItem (matches actionToJSON) — exercises
    // the migration's nested-JSON-string path too.
    const actionData = JSON.stringify({ type: "attack", currentItem: itemJsonStr });

    const flags = {
        [SID]: {
            itemName: "Martial Strike",
            itemJsonStr, // top-level JSON-string blob
            actionData, // double-nested JSON-string blob
        },
    };

    const flagBytes = JSON.stringify(flags).length;
    console.log(`Each message carries ~${(flagBytes / 1024).toFixed(1)} KB of flags.`);

    const created = [];
    for (let i = 0; i < COUNT; i++) {
        const msg = await ChatMessage.create({
            content: `<p>[REPRO] bloated maneuver message ${i + 1}/${COUNT}</p>`,
            flags,
        });
        created.push(msg.id);
    }

    console.log(`Created ${created.length} messages:`, created);
})();
```

</p>
</details> 