### PR TITLE
Use token name in adjustment

### DIFF
--- a/module/item/item-attack.mjs
+++ b/module/item/item-attack.mjs
@@ -3631,7 +3631,7 @@ export async function _onApplyEntangleToSpecificToken(item, token, originalRoll)
     ChatMessage.create(chatData);
 }
 
-export async function _onApplyDamageToEntangle(attackItem, token, originalRoll, entangleAE) {
+export async function _onApplyDamageToEntangle(attackItem, token, originalRoll, entangleAE, action) {
     // Get fully functional ActiveEffect that we can damage (update)
 
     // targetEntangle should belong to token
@@ -3747,6 +3747,7 @@ export async function _onApplyDamageToEntangle(attackItem, token, originalRoll, 
         tags: defenseTags,
         targetEntangle: true,
         attackTags: getAttackTags(attackItem),
+        attackerToken: tokenEducatedGuess({ action, actor: attackItem.actor }),
         targetToken: token,
     };
 

--- a/module/item/item-attack.mjs
+++ b/module/item/item-attack.mjs
@@ -3355,6 +3355,7 @@ export async function _onApplyDamageToSpecificToken(item, _damageData, action, t
         // misc
         tags: defenseTags.filter((o) => !o.options?.knockback),
         attackTags: getAttackTags(item),
+        attackerToken: tokenEducatedGuess({ action, actor: item.actor }),
         targetTokenDocument: targetToken?.document ?? targetToken,
         actionData: actionToJSON(action),
         showRemovePowerFromAutomaton: hasStun1 && damageDetail.body > 0,

--- a/module/utility/adjustment.mjs
+++ b/module/utility/adjustment.mjs
@@ -1199,7 +1199,7 @@ function _generateAdjustmentChatCard(
         isFade,
         //isEffectFinished,
         targetActor,
-        targetToken,
+        targetToken: targetToken || targetActor?.getActiveTokens()?.[0],
         attackerToken,
         startRound: game.combat?.round,
         startSegment: game.combat?.current?.segment,

--- a/templates/chat/apply-adjustment-card.hbs
+++ b/templates/chat/apply-adjustment-card.hbs
@@ -8,7 +8,7 @@
         {{/if}}
         <div class="flexrow">
             <img src="{{item.img}}" title="{{item.name}}" width="36" height="36" />
-            <h3>vs {{targetActor.name}}</h3>
+            <h3>vs {{#if targetToken}}{{targetToken.name}}{{else}}{{targetActor.name}}{{/if}}</h3>
         </div>
     </header>
 

--- a/templates/chat/apply-damage-card.hbs
+++ b/templates/chat/apply-damage-card.hbs
@@ -7,7 +7,7 @@
   </header>
 
   <div>
-    Attacker: <span class="item-name">{{#if isKnockBack}}Knockback{{else}}{{item.actor.name}}{{/if}}</span>
+    Attacker: <span class="item-name">{{#if isKnockBack}}Knockback{{else}}{{#if attackerToken}}{{attackerToken.name}}{{else}}{{item.actor.name}}{{/if}}{{/if}}</span>
   </div>
   <div>
     Attack: <span class="item-name">{{{itemNameHtml item}}}</span>


### PR DESCRIPTION
Fixes #4317 

Fixes a couple instances where the actor is used instead of the token name in damage and adjustment cards
Also fixes a miss in entangle damage where action is passed in but not accepted as an argument