### PR TITLE
Replace Dialog (v1) with DialogV2

### DIFF
--- a/module/actor/actor.mjs
+++ b/module/actor/actor.mjs
@@ -3032,8 +3032,8 @@ export class HeroSystem6eActor extends HeroObjectCacheMixin(Actor) {
                             .join("") +
                         `</ul></div>`;
                     const content = `The following items were not included in the HDC file. Do you want to delete them? ${unorderedList}`;
-                    const confirmDeleteExtraItems = await Dialog.confirm({
-                        title: `${this.name}: Delete extra items?`,
+                    const confirmDeleteExtraItems = await foundry.applications.api.DialogV2.confirm({
+                        window: { title: `${this.name}: Delete extra items?` },
                         content: content,
                     });
 

--- a/module/applications/actor/actor-sheet-v2.mjs
+++ b/module/applications/actor/actor-sheet-v2.mjs
@@ -212,12 +212,6 @@ export class HeroSystemActorSheetV2 extends HandlebarsApplicationMixin(ActorShee
             ],
         });
 
-        // const confirmed = await Dialog.confirm({
-        //     title: game.i18n.localize("HERO6EFOUNDRYVTTV2.confirms.fullHealthConfirm.Title") + ` [${this.actor.name}]`,
-        //     content: game.i18n.localize("HERO6EFOUNDRYVTTV2.confirms.fullHealthConfirm.Content"),
-        // });
-        // if (!confirmed) return;
-
         switch (action) {
             case "fullHealth":
                 return this.actor.fullHealth();
@@ -257,8 +251,8 @@ export class HeroSystemActorSheetV2 extends HandlebarsApplicationMixin(ActorShee
     }
 
     static async #onDeleteAllTemporaryEffects() {
-        const confirm = await Dialog.confirm({
-            title: "Delete all Temporary Effects",
+        const confirm = await foundry.applications.api.DialogV2.confirm({
+            window: { title: "Delete all Temporary Effects" },
             content:
                 `<h4>Are you sure?</h4><p>This will permanently delete all ${this.actor.temporaryEffects.length} ` +
                 `temporary effects.</p>`,
@@ -273,8 +267,8 @@ export class HeroSystemActorSheetV2 extends HandlebarsApplicationMixin(ActorShee
     }
 
     static async #onDeleteAllActiveEffects() {
-        const confirm = await Dialog.confirm({
-            title: "Delete all activeEffects",
+        const confirm = await foundry.applications.api.DialogV2.confirm({
+            window: { title: "Delete all activeEffects" },
             content:
                 `<h4>Are you sure?</h4><p>This will attempt to permanently delete all ${Array.from(this.actor.allApplicableEffects()).length} ` +
                 `active effects.  Some effects will get re-applied.  This may break some powers and/or automation, requiring a re-upload of HDC or FullHealth+Rebuild to fix.</p>`,

--- a/module/compendiumDirectory.mjs
+++ b/module/compendiumDirectory.mjs
@@ -44,111 +44,55 @@ export class HeroSystem6eCompendiumDirectory extends FoundryVttCompendiumDirecto
                 `Document.</p><label>Hero Designer Prefab</label><input name="upload" class="upload" type="file" accept=".hdp"></input>`,
             );
 
-            if (game.version.split(".")[0] !== "12") {
-                const { DialogV2 } = foundry.applications.api;
+            const { DialogV2 } = foundry.applications.api;
 
-                // DialogV2RenderCallback
-                function handleRender(event, dialog) {
-                    const inputUpload = dialog.element.querySelector("input.upload");
-                    inputUpload.addEventListener("change", (event) => {
-                        console.log(event, event.target.files[0]);
-                        const reader = new FileReader();
-                        reader.onload = async function (event) {
-                            const contents = event.target.result;
+            // DialogV2RenderCallback
+            function handleRender(event, dialog) {
+                const inputUpload = dialog.element.querySelector("input.upload");
+                inputUpload.addEventListener("change", (event) => {
+                    console.log(event, event.target.files[0]);
+                    const reader = new FileReader();
+                    reader.onload = async function (event) {
+                        const contents = event.target.result;
 
-                            const parser = new DOMParser();
-                            const xmlDoc = parser.parseFromString(contents, "text/xml");
-                            // TODO create the Item compendium
-                            HeroSystem6eCompendiumDirectory.uploadFromXml(xmlDoc);
-                        }.bind(this);
-                        reader.readAsText(event.target.files[0]);
+                        const parser = new DOMParser();
+                        const xmlDoc = parser.parseFromString(contents, "text/xml");
+                        // TODO create the Item compendium
+                        HeroSystem6eCompendiumDirectory.uploadFromXml(xmlDoc);
+                    }.bind(this);
+                    reader.readAsText(event.target.files[0]);
 
-                        // Close Create Compendium message box
-                        $(event.currentTarget).closest(".window-content").find("button").click();
-                    });
-                }
-
-                const content = document.createElement("div");
-                content.innerHTML = html;
-                const metadata = await DialogV2.prompt({
-                    content: game.version.split(".")[0] === "12" ? html : content,
-                    id: "create-compendium",
-                    window: { title: "COMPENDIUM.Create" },
-                    position: { width: 480 },
-                    ok: {
-                        label: "COMPENDIUM.Create",
-                        callback: (_event, button) => new FoundryVttFormDataExtended(button.form).object,
-                    },
-                    render: handleRender,
+                    // Close Create Compendium message box
+                    $(event.currentTarget).closest(".window-content").find("button").click();
                 });
-                if (!metadata) return;
-                if (metadata.upload) return;
-                const targetFolderId = metadata.folder;
-                delete metadata.folder;
-                if (!metadata.label) {
-                    const count = game.packs.size;
-                    metadata.label = game.i18n.format(count ? "DOCUMENT.NewCount" : "DOCUMENT.New", {
-                        count: count + 1,
-                        type: game.i18n.localize("PACKAGE.TagCompendium"),
-                    });
-                }
-                const pack = await CompendiumCollection.createCompendium(metadata);
-                if (targetFolderId) await pack.setFolder(targetFolderId);
-            } else {
-                function handleRender(html) {
-                    html.on("change", "input.upload", (event) => {
-                        console.log(event, event.target.files[0]);
-                        const reader = new FileReader();
-                        reader.onload = async function (event) {
-                            const contents = event.target.result;
-
-                            const parser = new DOMParser();
-                            const xmlDoc = parser.parseFromString(contents, "text/xml");
-                            // TODO create the Item compendium
-                            HeroSystem6eCompendiumDirectory.uploadFromXml(xmlDoc);
-                        }.bind(this);
-                        reader.readAsText(event.target.files[0]);
-
-                        // Close Create Compendium message box
-                        $(event.currentTarget).closest(".window-content").find("button").click();
-                    });
-                }
-                return new Dialog({
-                    title: game.i18n.localize("COMPENDIUM.Create"),
-                    content: html,
-                    //label: game.i18n.localize("COMPENDIUM.Create"),
-                    buttons: {
-                        create: {
-                            label: game.i18n.localize("COMPENDIUM.Create"),
-                            callback: async (html) => {
-                                const form = html.find("#compendium-create")[0];
-                                const fd = new FoundryVttFormDataExtended(form);
-                                const metadata = fd.object;
-
-                                if (metadata.upload) {
-                                    return; // We handle this in the onchage event above because browser security use fakepath
-                                }
-
-                                let targetFolderId = metadata.folder;
-                                if (metadata.folder) delete metadata.folder;
-                                if (!metadata.label) {
-                                    let defaultName = game.i18n.format("DOCUMENT.New", {
-                                        type: game.i18n.localize("PACKAGE.TagCompendium"),
-                                    });
-                                    const count = game.packs.size;
-                                    if (count > 0) defaultName += ` (${count + 1})`;
-                                    metadata.label = defaultName;
-                                }
-                                const pack = await CompendiumCollection.createCompendium(metadata);
-                                if (targetFolderId) await pack.setFolder(targetFolderId);
-                            },
-                        },
-                    },
-                    render: handleRender,
-                    rejectClose: false,
-                    options: { jQuery: false },
-                }).render(true);
             }
+
+            const content = document.createElement("div");
+            content.innerHTML = html;
+            const metadata = await DialogV2.prompt({
+                content,
+                id: "create-compendium",
+                window: { title: "COMPENDIUM.Create" },
+                position: { width: 480 },
+                ok: {
+                    label: "COMPENDIUM.Create",
+                    callback: (_event, button) => new FoundryVttFormDataExtended(button.form).object,
+                },
+                render: handleRender,
+            });
+            if (!metadata) return;
+            if (metadata.upload) return;
+            const targetFolderId = metadata.folder;
+            delete metadata.folder;
+            if (!metadata.label) {
+                const count = game.packs.size;
+                metadata.label = game.i18n.format(count ? "DOCUMENT.NewCount" : "DOCUMENT.New", {
+                    count: count + 1,
+                    type: game.i18n.localize("PACKAGE.TagCompendium"),
+                });
+            }
+            const pack = await CompendiumCollection.createCompendium(metadata);
+            if (targetFolderId) await pack.setFolder(targetFolderId);
         } catch (e) {
             console.error(e);
             super._onCreateEntry(event, target);

--- a/module/heroCompendiums.mjs
+++ b/module/heroCompendiums.mjs
@@ -48,17 +48,16 @@ async function CreateHeroMacros() {
         name: "Full Health all owned tokens in scene",
         type: "script",
         command: `
-        Dialog.confirm({
-  title: "Full Health",
+        const confirmed = await foundry.applications.api.DialogV2.confirm({
+  window: { title: "Full Health" },
   content: '<p>You are about to heal ' + game.scenes.current.tokens.filter(o=>o.isOwner).length + ' tokens in this scene. This is the same as clicking "Full Health" on each actor sheet. This includes setting all characteristics to max, removing status effects and removing temporary effects.  Do you want to continue?</p>',
-  label: "Full Health",
-  yes: () => {
-      for(const token of game.scenes.current.tokens.filter(o=>o.isOwner)) {
-        console.log(token);
-      token.actor?.fullHealth();
-      }
-    }
 });
+if (confirmed) {
+  for(const token of game.scenes.current.tokens.filter(o=>o.isOwner)) {
+    console.log(token);
+    token.actor?.fullHealth();
+  }
+}
         `,
         flags: {
             [`${game.system.id}.versionHeroSystem6eManuallyCreated`]: game.system.version,

--- a/module/heroRoller/genericRoller.mjs
+++ b/module/heroRoller/genericRoller.mjs
@@ -59,17 +59,14 @@ export class GenericRoller {
             options,
         );
 
-        const userSelection = await Dialog.prompt({
-            title: "Roll ToHit",
-            label: "Roll ToHit",
+        const userSelection = await foundry.applications.api.DialogV2.prompt({
+            window: { title: "Roll ToHit" },
             content: template,
-            callback: async function (html) {
-                const form = html.find("form")[0];
-                return new FoundryVttFormDataExtended(form).object;
+            ok: {
+                label: "Roll ToHit",
+                callback: (event, button) => new FoundryVttFormDataExtended(button.form).object,
             },
-        }).catch(() => {
-            // Promise is rejected most likely from user choosing close
-            return undefined;
+            rejectClose: false,
         });
 
         // No user selection? If so, don't roll.
@@ -147,17 +144,14 @@ export class GenericRoller {
             `systems/${HEROSYS.module}/templates/system/heroRoll-damage.hbs`,
             options,
         );
-        const userSelection = await Dialog.prompt({
-            title: "Roll Damage",
-            label: "Roll Damage",
+        const userSelection = await foundry.applications.api.DialogV2.prompt({
+            window: { title: "Roll Damage" },
             content: template,
-            callback: async function (html) {
-                const form = html.find("form")[0];
-                return new FoundryVttFormDataExtended(form).object;
+            ok: {
+                label: "Roll Damage",
+                callback: (event, button) => new FoundryVttFormDataExtended(button.form).object,
             },
-        }).catch(() => {
-            // Promise is rejected most likely from user choosing close
-            return undefined;
+            rejectClose: false,
         });
 
         // No user selection? If so, don't roll.

--- a/module/item/item-attack.mjs
+++ b/module/item/item-attack.mjs
@@ -5175,7 +5175,7 @@ export async function _onModalDamageCard(event) {
     content.find(".modal-damage-card").remove();
     content = content.html();
 
-    await new foundry.applications.api.DialogV2({
+    const dialog = new foundry.applications.api.DialogV2({
         window: { title: `Modal Damage` },
         content,
         buttons: [
@@ -5184,8 +5184,18 @@ export async function _onModalDamageCard(event) {
                 label: "Close",
             },
         ],
-        render: (event, dialog) => {
-            this.chatListeners(dialog.element);
-        },
-    }).render({ force: true });
+    });
+
+    // DialogV2 wraps content in a <form> and only honors the `render` option via its static
+    // wait/prompt/confirm helpers, so wire the listener ourselves. The cloned card's buttons
+    // would otherwise submit (and close) the dialog; force them to type="button" so their
+    // delegated chat handlers run instead.
+    dialog.addEventListener("render", () => {
+        for (const button of dialog.element.querySelectorAll(".dialog-content button")) {
+            button.setAttribute("type", "button");
+        }
+        this.chatListeners(dialog.element);
+    });
+
+    await dialog.render({ force: true });
 }

--- a/module/item/item-attack.mjs
+++ b/module/item/item-attack.mjs
@@ -342,23 +342,22 @@ export async function getTargetArray(formData) {
                 html += `<li style="text-align:left">${target.name}</li>`;
             }
             html += "</ol></td></tr></table>";
-            targetArray = await Dialog.wait({
-                title: `Pick target list`,
+            targetArray = await foundry.applications.api.DialogV2.wait({
+                window: { title: `Pick target list` },
                 content: html,
-                buttons: {
-                    gm: {
+                buttons: [
+                    {
+                        action: "gm",
                         label: game.user.name,
-                        callback: async function () {
-                            return targetArray;
-                        },
+                        default: true,
+                        callback: () => targetArray,
                     },
-                    user: {
+                    {
+                        action: "user",
                         label: game.users.get(formData.userId).name,
-                        callback: async function () {
-                            return userTargetArray;
-                        },
+                        callback: () => userTargetArray,
                     },
-                },
+                ],
             });
         }
     }
@@ -1638,26 +1637,24 @@ export async function _onRollKnockback(event) {
     </form>
     `;
 
-    await new Promise((resolve) => {
-        const data = {
-            title: `Confirm Knockback details`,
-            content: html,
-            buttons: {
-                normal: {
-                    label: "Roll & Apply",
-                    callback: async function (html) {
-                        const dice = html.find("input")[0].value;
-                        await _rollApplyKnockback(token, parseInt(dice));
-                    },
-                },
-                cancel: {
-                    label: "Cancel",
+    await foundry.applications.api.DialogV2.wait({
+        window: { title: `Confirm Knockback details` },
+        content: html,
+        buttons: [
+            {
+                action: "normal",
+                label: "Roll & Apply",
+                default: true,
+                callback: async (event, button) => {
+                    const dice = button.form.elements.knockbackDice.value;
+                    await _rollApplyKnockback(token, parseInt(dice));
                 },
             },
-            default: "normal",
-            close: () => resolve({ cancelled: true }),
-        };
-        new Dialog(data).render(true);
+            {
+                action: "cancel",
+                label: "Cancel",
+            },
+        ],
     });
 }
 
@@ -2999,23 +2996,22 @@ export async function _onApplyDamageToSpecificToken(item, _damageData, action, t
         // If they clicked "Apply Damage" then prompt
         // WHAT? if (damageRoller.getType === HeroRoller.ROLL_TYPE.ENTANGLE) {
         if (damageRoller.getType() !== HeroRoller.ROLL_TYPE.ENTANGLE && targetEntangle === undefined) {
-            targetEntangle = await Dialog.wait({
-                title: `Confirm Target`,
+            targetEntangle = await foundry.applications.api.DialogV2.wait({
+                window: { title: `Confirm Target` },
                 content: `Target ${targetToken.name} or the ENTANGLE effecting ${targetToken.name}?`,
-                buttons: {
-                    token: {
+                buttons: [
+                    {
+                        action: "token",
                         label: `${targetToken.name}`,
-                        callback: async function () {
-                            return false;
-                        },
+                        default: true,
+                        callback: () => false,
                     },
-                    entangle: {
+                    {
+                        action: "entangle",
                         label: `ENTANGLE`,
-                        callback: async function () {
-                            return true;
-                        },
+                        callback: () => true,
                     },
-                },
+                ],
             });
         }
 
@@ -3870,23 +3866,24 @@ async function _onApplyAdjustmentToSpecificToken(adjustmentItem, token, damageDe
             }
             html += `</table>`;
 
-            const data = {
-                title: `Pick power to adjust`,
-                content: html,
-                buttons: {
-                    normal: {
-                        label: "Apply",
-                        callback: async function (html) {
-                            return html.find("input:checked");
+            const checked =
+                (await foundry.applications.api.DialogV2.wait({
+                    window: { title: `Pick power to adjust` },
+                    content: html,
+                    buttons: [
+                        {
+                            action: "normal",
+                            label: "Apply",
+                            default: true,
+                            callback: (event, button) => Array.from(button.form.querySelectorAll("input:checked")),
                         },
-                    },
-                    cancel: {
-                        label: "Cancel",
-                    },
-                },
-            };
-
-            const checked = await Dialog.wait(data);
+                        {
+                            action: "cancel",
+                            label: "Cancel",
+                            callback: () => [],
+                        },
+                    ],
+                })) || [];
 
             for (const checkedElement of checked) {
                 const checkedItem = token.actor.items.find((o) => o.id === checkedElement.id);
@@ -4658,9 +4655,9 @@ export async function userInteractiveVerifyOptionallyPromptThenSpendResources(it
         const potentialStunCost = calculateRequiredStunDiceForLackOfEnd(actor, resourcesRequired.totalEnd);
 
         if (!options.forceStunUsage) {
-            const confirmed = await Dialog.confirm({
-                title: "USING STUN FOR ENDURANCE",
-                content: `<p><b>${item.name}</b> requires ${resourcesRequired.totalEnd} END. <b>${actor.name}</b> has ${actorEndurance} END. 
+            const confirmed = await foundry.applications.api.DialogV2.confirm({
+                window: { title: "USING STUN FOR ENDURANCE" },
+                content: `<p><b>${item.name}</b> requires ${resourcesRequired.totalEnd} END. <b>${actor.name}</b> has ${actorEndurance} END.
                                 Do you want to take ${potentialStunCost.stunDice}d6 STUN damage to make up for the lack of END?</p>`,
             });
             if (!confirmed) {
@@ -5178,20 +5175,17 @@ export async function _onModalDamageCard(event) {
     content.find(".modal-damage-card").remove();
     content = content.html();
 
-    const data = {
-        title: `Modal Damage`,
+    await new foundry.applications.api.DialogV2({
+        window: { title: `Modal Damage` },
         content,
-        buttons: {
-            cancel: {
+        buttons: [
+            {
+                action: "cancel",
                 label: "Close",
             },
+        ],
+        render: (event, dialog) => {
+            this.chatListeners(dialog.element);
         },
-        default: "Cancel",
-        render: (html) => {
-            this.chatListeners(html);
-        },
-        //close: () => resolve({ cancelled: true }),
-    };
-    const d = new Dialog(data, { form: { closeOnSubmit: false } });
-    await d.render(true);
+    }).render({ force: true });
 }

--- a/module/item/skill.mjs
+++ b/module/item/skill.mjs
@@ -140,7 +140,7 @@ export async function createSkillPopOutFromItem(item, actor) {
                 action: "rollSkill",
                 label: "Roll Skill",
                 default: true,
-                callback: () => skillRoll(item, actor),
+                callback: (event, button) => skillRoll(item, actor, button.form),
             },
         ],
     });
@@ -152,7 +152,7 @@ export async function createSkillPopOutFromItem(item, actor) {
 
 // PH: FIXME: This will need some split apart into a "do I need to do a roll" and "do the skill roll".
 
-async function skillRoll(item, actor, target) {
+async function skillRoll(item, actor, formElement) {
     const token = actor.token;
     const speaker = ChatMessage.getSpeaker({ actor: actor, token });
 
@@ -173,7 +173,6 @@ async function skillRoll(item, actor, target) {
         return ChatMessage.create(chatData);
     }
 
-    const formElement = target[0].querySelector("form");
     const formData = new FoundryVttFormDataExtended(formElement)?.object;
     const skillRoller = new HeroRoller().addDice(3);
 
@@ -268,8 +267,8 @@ async function skillRoll(item, actor, target) {
     const total = skillRoller.getSuccessTotal();
     const margin = successValue - total;
 
-    const untrainedSkillXmlid = target.find("[name='untrainedSkill']")?.[0]?.value;
-    const untrainedSkillName = target.find("[name='untrainedSkill'] option:selected")?.[0]?.text;
+    const untrainedSkillXmlid = formElement.querySelector("[name='untrainedSkill']")?.value;
+    const untrainedSkillName = formElement.querySelector("[name='untrainedSkill'] option:selected")?.text;
 
     let disadFlavor = "";
     switch (untrainedSkillXmlid ?? item.system.XMLID) {

--- a/module/item/skill.mjs
+++ b/module/item/skill.mjs
@@ -131,26 +131,21 @@ export async function createSkillPopOutFromItem(item, actor) {
     const content = await _renderSkillForm(item, actor, {});
 
     // Attack Card as a Pop Out
-    let options = {
-        width: 500,
-    };
-
-    return new Promise((resolve) => {
-        const data = {
-            title: "Roll Skill",
-            content: content,
-            buttons: {
-                rollSkill: {
-                    label: "Roll Skill",
-                    callback: (target, event) => resolve(skillRoll(item, actor, target, event)),
-                },
+    const result = await foundry.applications.api.DialogV2.wait({
+        window: { title: "Roll Skill" },
+        position: { width: 500 },
+        content,
+        buttons: [
+            {
+                action: "rollSkill",
+                label: "Roll Skill",
+                default: true,
+                callback: () => skillRoll(item, actor),
             },
-            default: "rollSkill",
-            close: () => resolve({}),
-        };
-
-        new Dialog(data, options).render(true);
+        ],
     });
+
+    return result ?? {};
 }
 
 // PH: FIXME: Create a chat message for resource consumption.

--- a/module/item/skill.mjs
+++ b/module/item/skill.mjs
@@ -267,8 +267,9 @@ async function skillRoll(item, actor, formElement) {
     const total = skillRoller.getSuccessTotal();
     const margin = successValue - total;
 
-    const untrainedSkillXmlid = formElement.querySelector("[name='untrainedSkill']")?.value;
-    const untrainedSkillName = formElement.querySelector("[name='untrainedSkill'] option:selected")?.text;
+    const untrainedSkillSelect = formElement.querySelector("[name='untrainedSkill']");
+    const untrainedSkillXmlid = untrainedSkillSelect?.value;
+    const untrainedSkillName = untrainedSkillSelect?.selectedOptions?.[0]?.text;
 
     let disadFlavor = "";
     switch (untrainedSkillXmlid ?? item.system.XMLID) {

--- a/module/testing/end-to-end.mjs
+++ b/module/testing/end-to-end.mjs
@@ -22,26 +22,27 @@ export class HeroSystem6eEndToEndTest {
 
     async start() {
         // Close existing dialog window if it exists
-        $(".dialog.end-to-end-testing button[data-button='ok']").click();
+        $(".dialog.end-to-end-testing button[data-action='ok']").click();
 
         // Wait for previous dialog to close
         for (let i = 0; i < 50; i++) {
-            if ($(".dialog.end-to-end-testing button[data-button='ok']").length === 0) break;
+            if ($(".dialog.end-to-end-testing button[data-action='ok']").length === 0) break;
             await this.delay();
         }
 
         // Create new dialog
-        await new Dialog({
-            title: `End To End Testing`,
+        await new foundry.applications.api.DialogV2({
+            window: { title: `End To End Testing` },
             content: `<div style="height:400px; overflow-y:scroll"><ol class="end-to-end-testing">
                 <li>Init</li>
             </ol></div>`,
-            buttons: {
-                ok: {
+            buttons: [
+                {
+                    action: "ok",
                     label: "OK",
                 },
-            },
-        }).render(true);
+            ],
+        }).render({ force: true });
 
         for (let i = 0; i < 50; i++) {
             if ((this.orderedListElement = $(".dialog .end-to-end-testing")).length > 0) break;

--- a/module/utility/defense.mjs
+++ b/module/utility/defense.mjs
@@ -560,35 +560,23 @@ export async function getConditionalDefenses(token, item, avad) {
         const conditionalDefenseCardTemplate = `systems/${HEROSYS.module}/templates/attack/item-conditional-defense-card.hbs`;
         const html = await foundryVttRenderTemplate(conditionalDefenseCardTemplate, data);
 
-        async function getDialogOutput() {
-            return new Promise((resolve) => {
-                const dataConditionalDefenses = {
-                    title: token.name + " conditional defenses",
-                    content: html,
-                    buttons: {
-                        normal: {
-                            label: "Apply Damage",
-                            callback: (html) => {
-                                resolve(html.find("form input"));
-                            },
-                        },
-                        cancel: {
-                            label: "Cancel",
-                            callback: () => {
-                                resolve(null);
-                            },
-                        },
-                    },
-                    default: "normal",
-                    close: () => {
-                        resolve(null);
-                    },
-                };
-                new Dialog(dataConditionalDefenses).render(true);
-            });
-        }
-
-        const inputs = await getDialogOutput();
+        const inputs = await foundry.applications.api.DialogV2.wait({
+            window: { title: token.name + " conditional defenses" },
+            content: html,
+            buttons: [
+                {
+                    action: "normal",
+                    label: "Apply Damage",
+                    default: true,
+                    callback: (event, button) => Array.from(button.form.querySelectorAll("input")),
+                },
+                {
+                    action: "cancel",
+                    label: "Cancel",
+                    callback: () => null,
+                },
+            ],
+        });
         if (inputs === null) {
             return { ignoreDefenseIds: null, conditionalDefenses: null };
         }

--- a/module/utility/defense.mjs
+++ b/module/utility/defense.mjs
@@ -561,6 +561,8 @@ export async function getConditionalDefenses(token, item, avad) {
         const html = await foundryVttRenderTemplate(conditionalDefenseCardTemplate, data);
 
         const inputs = await foundry.applications.api.DialogV2.wait({
+            classes: ["herosystem6e"],
+            position: { width: 400 },
             window: { title: token.name + " conditional defenses" },
             content: html,
             buttons: [

--- a/scss/components/_active-effects.scss
+++ b/scss/components/_active-effects.scss
@@ -8,7 +8,7 @@
 
 div.herosystem-active-effect-config div.description {
     background-color: rgb(0 0 0 / 10%);
-    border: 1px dashed rgb(0 0 0 / 50%);
+    border: 1px dashed var(--input-border-color);
     padding: 5px;
     max-width: 100%;
     user-select: text;

--- a/scss/components/_actor-sheet.scss
+++ b/scss/components/_actor-sheet.scss
@@ -365,10 +365,24 @@
     padding-top: 5px;
 }
 
-.conditional-defense-card div.description {
-    border: 1px dashed rgb(0 0 0 / 50%);
-    margin: 15px 0;
-    padding: 5px;
+.conditional-defense-card {
+    h2 {
+        font-family: inherit;
+        font-size: var(--font-size-16);
+        font-weight: 600;
+        line-height: 1.4;
+        border: none;
+        margin: 0 0 5px;
+    }
+
+    div.description {
+        border: 1px dashed var(--input-border-color);
+        background: var(--input-background-color);
+        color: var(--input-text-color);
+        margin: 15px 0;
+        padding: 5px;
+        overflow-wrap: anywhere;
+    }
 }
 
 td.characteristic-locked > input {
@@ -420,7 +434,7 @@ form.item-sheet h1.charname input {
 .herosystem6e.sheet.item div.description,
 form div.attack-card div.description {
     background-color: rgb(0 0 0 / 10%);
-    border: 1px dashed rgb(0 0 0 / 50%);
+    border: 1px dashed var(--input-border-color);
     margin: 15px 0;
     padding: 5px;
     max-width: 100%;

--- a/scss/components/_item-attack.scss
+++ b/scss/components/_item-attack.scss
@@ -33,9 +33,9 @@
     }
 
     div.description {
-        color: var(--color-text-primary);
-        background: color-mix(in srgb, currentColor 8%, transparent);
-        border: 1px solid color-mix(in srgb, currentColor 35%, transparent);
+        border: 1px dashed var(--input-border-color);
+        background: var(--input-background-color);
+        color: var(--input-text-color);
     }
 
     .multi-attack-options.target-container {

--- a/scss/herosystem6e.scss
+++ b/scss/herosystem6e.scss
@@ -36,6 +36,9 @@ body {
     --herosystem-header-background: var(--table-header-bg-color);
     --herosystem-item-row-border: rgb(var(--herosystem-blue) / 20%);
     --herosystem-header-text: var(--table-header-text-color);
+    --input-border-color: var(--color-dark-4, rgb(0 0 0 / 50%));
+    --input-text-color: var(--color-dark-2);
+    --input-background-color: var(--color-light-2);
 }
 
 body.theme-light .herosystem6e,
@@ -51,6 +54,9 @@ body.theme-dark .herosystem6e:not(.themed),
     --background: black;
     --herosystem-search-background: var(--color-dark-3); // 333
     --herosystem-search-text: var(--color-light-1); // #f7f3e8
+    --input-border-color: var(--color-light-4, rgb(255 255 255 / 40%));
+    --input-text-color: var(--color-light-2);
+    --input-background-color: var(--color-dark-3);
 }
 
 // ref: https://venngage.com/tools/accessible-color-palette-generator

--- a/templates/attack/item-conditional-defense-card.hbs
+++ b/templates/attack/item-conditional-defense-card.hbs
@@ -1,5 +1,5 @@
 {{ log 'HEROSYS item-conditional-defense-card' this }}
-<form class="hero chat-card item-card conditional-defense-card" data-actor-id="{{actor._id}}"
+<div class="hero chat-card item-card conditional-defense-card" data-actor-id="{{actor._id}}"
     data-item-id="{{item._id}}" {{#if tokenId}}data-token-id="{{tokenId}}" {{/if}}>
 
     <div class="hero chat-card item-card">
@@ -26,4 +26,4 @@
         </table>
     </div>
 
-</form>
+</div>


### PR DESCRIPTION
Fixes #4396

Dialog (AppV1) is deprecated. Migrate all Dialog usages in v2 applications and global/document paths to foundry.applications.api.DialogV2. v1 sheet classes are intentionally excluded — they're slated for wholesale removal before the deprecation bites.

- Dialog.confirm/prompt/wait and new Dialog(...) > DialogV2 equivalents (window.title, buttons array with action, button.form for form extraction).
- compendiumDirectory.mjs: drops the dead game.version === "12" legacy branch.
- compendium directory + full-health macro, actor delete-extra-items prompt, v2 actor-sheet effect confirms, generic roller, attack dialogs, skill-roll popout, conditional defenses, e2e test dialog.
- Modal damage card: render is ignored on the new DialogV2() path (only static wait/prompt/confirm honor it), and DialogV2 wraps content in a submit-form (closeOnSubmit: true). Wire the render listener manually and force content buttons to type="button" so the delegated chat handlers fire instead of closing the dialog.

Smoke tests (v13; spot-check v14)

Verify each dialog opens, its buttons act correctly, and closing via X is clean.

1. Generic roller ToHit and Damage > fill form > Roll; confirm selections land in the chat card.
2. Land an attack causing Knockback > change the dice value > Roll & Apply; confirm the entered value is used.
3. Apply damage to a target with conditional defenses > uncheck one > Apply Damage; confirm it's ignored.
4. Create Compendium (sidebar), including the HDP upload field.
5. Skill roll popout > Roll Skill produces a roll reflecting the untrained-skill/mod selections.
6. v2 actor sheet > Delete all Temporary Effects / Delete all Active Effects.
7. STUN-for-END prompt (attack needs more END than available; actor has STUN).
8. Re-upload an HDC with fewer items > delete extra items prompt.
9. Full Health all owned tokens macro (Hero macros compendium).
10. GM targets differ from player's > Pick target list; and attack a token with an ENTANGLE effect > Confirm Target.
11. Modal damage card: click the modal-damage-card icon on a damage card > popup opens and its "Apply Damage" buttons
work (dialog stays open); Close still closes.