### PR TITLE
Stale fields on submit, 5e figured characteristic clamping on override

### DIFF
--- a/module/actor/actor.mjs
+++ b/module/actor/actor.mjs
@@ -1218,8 +1218,17 @@ export class HeroSystem6eActor extends HeroObjectCacheMixin(Actor) {
 
         // Block A source: purchased LEVELS changed for a characteristic (e.g. HDC upload / edit).
         // Keep the original (schema-cased) key so we can patch system.<KEY>.LEVELS below.
+        // Only an actual LEVELS change counts: payloads that merely echo the current LEVELS
+        // (full-object round-trips) must not resync value/max to base+LEVELS, which would strip
+        // adjustment (AID/DRAIN) results from the stored value.
         const levelsChanged = Object.keys(systemChanged)
-            .filter((k) => systemChanged[k]?.LEVELS != null && this.hasCharacteristic(k.toUpperCase()))
+            .filter(
+                (k) =>
+                    systemChanged[k]?.LEVELS != null &&
+                    this.hasCharacteristic(k.toUpperCase()) &&
+                    Number(systemChanged[k].LEVELS) !==
+                        Number(foundry.utils.getProperty(this.system, `${k}.LEVELS`) ?? 0),
+            )
             .map((k) => ({ origKey: k, key: k.toLowerCase() }));
 
         // Block B source: a characteristic value changed and it feeds a calculated dependent.

--- a/module/actor/actor.mjs
+++ b/module/actor/actor.mjs
@@ -389,6 +389,9 @@ export class HeroSystem6eActor extends HeroObjectCacheMixin(Actor) {
                         // - A dependent resting untouched at its stored maximum (no damage, no
                         //   value-targeting effects) FOLLOWS the max in both directions — a bigger
                         //   STR means a longer leap right now, not just a higher ceiling.
+                        // - A stored value deliberately set above the stored max (GM overfill; both
+                        //   sheets style it with the over-max class, and 6e has no cap at all) is
+                        //   user intent and must survive the recompute.
                         // - Otherwise only cap DOWN (e.g. Prone halving DCV). Never raise a diverged
                         //   value: for expendables (STUN/END) the gap below max is damage/spent
                         //   points and raising it would silently heal them on every render, and a
@@ -400,8 +403,12 @@ export class HeroSystem6eActor extends HeroObjectCacheMixin(Actor) {
                             const restingAtStoredMax =
                                 currentValue === Number(sourceNode.value) &&
                                 Number(sourceNode.value) === Number(sourceNode.max);
+                            const storedOverMax = Number(sourceNode.value) > Number(sourceNode.max);
 
-                            let coherentValue = restingAtStoredMax ? node.max : Math.min(currentValue, node.max);
+                            let coherentValue;
+                            if (restingAtStoredMax) coherentValue = node.max;
+                            else if (storedOverMax) coherentValue = currentValue;
+                            else coherentValue = Math.min(currentValue, node.max);
                             // Effects that halve the current value directly can leave a fraction
                             // behind; apply Hero rounding (SPD always rounds down, 5ER p. 33).
                             if (!Number.isInteger(coherentValue)) {

--- a/module/applications/actor/actor-sheet-v2.mjs
+++ b/module/applications/actor/actor-sheet-v2.mjs
@@ -995,6 +995,31 @@ export class HeroSystemActorSheetV2 extends HandlebarsApplicationMixin(ActorShee
     }
 
     /**
+     * AppV2 form submission serializes every named input on the sheet, so any submit (Enter key,
+     * ClientDocument#sortRelative, ...) would re-write dozens of fields the user never touched.
+     * Those writes are not no-ops: an unchanged system.<KEY>.LEVELS in the payload makes
+     * _apply5eCalculatedCharacteristics resync that characteristic to base+LEVELS, silently
+     * reverting adjustment (AID/DRAIN) results on value/max. Every editable input on this sheet
+     * already persists itself through the per-input change listeners in _onRender, so form-level
+     * submits contribute no form data. Programmatic submit({updateData}) calls still work:
+     * updateData is merged in _prepareSubmitData after this returns.
+     */
+    _processFormData() {
+        return {};
+    }
+
+    /**
+     * Core _prepareSubmitData validates with clean:{addTypes:true, copy:false}, which injects
+     * `type` even into an empty payload. Writing that lone `type` is not harmless: the actor's
+     * _preUpdate runs its KO/stun-threshold logic whenever changed.type is present. Skip the
+     * update entirely when there is nothing real to write.
+     */
+    async _processSubmitData(event, form, submitData, options) {
+        if (Object.keys(submitData ?? {}).every((k) => k === "type")) return;
+        return super._processSubmitData(event, form, submitData, options);
+    }
+
+    /**
      * Define whether a user is able to begin a dragstart workflow for a given drag selector
      * @param {string} selector       The candidate HTML selector for dragging
      * @returns {boolean}             Can the current user drag this selector?


### PR DESCRIPTION
Fixes #4427 

* Hitting enter in a focused field should no longer override with stale values due to form submit on AppV2 char sheet
* 5e figured characteristics should no longer set to max after being overridden to a value above max.