### PR TITLE
perf: skip idle actors and batch effect expiry in updateWorldTime

### DIFF
--- a/module/actor/actor.mjs
+++ b/module/actor/actor.mjs
@@ -2680,6 +2680,8 @@ export class HeroSystem6eActor extends HeroObjectCacheMixin(Actor) {
         It is subtle and identified as an issue with V14 where effect is suppressed instead of disabled/deleted
         when duration expires.
         This may require a CONFIG.ActiveEffect.expiryAction = "delete" fix at some point.
+        NOTE: actorHasTemporaryEffects (herosystem6e.mjs) is a cheap non-empty check that must
+        mirror this filter; keep them in sync.
     */
     getTemporaryEffects() {
         return Array.from(this.allApplicableEffects())

--- a/module/herosystem6e.mjs
+++ b/module/herosystem6e.mjs
@@ -750,70 +750,103 @@ Hooks.on("getActorDirectoryEntryContext", (_dialog, html) => {
 let secondsSinceRecovery = 0;
 
 /**
+ * Cheap non-empty equivalent of actor.getTemporaryEffects() (no Array.from/filter/sort).
+ * Intentionally ignores `active` so suppressed temporary item effects still qualify.
+ * @param {HeroSystem6eActor} actor
+ * @returns {boolean}
+ */
+function actorHasTemporaryEffects(actor) {
+    for (const ae of actor.allApplicableEffects()) {
+        if (ae.isTemporary) return true;
+    }
+    return false;
+}
+
+// Foundry does not await async hook callbacks, so rapid time advances (combat clicking,
+// large calendar jumps) can otherwise overlap and double-process the same effects.
+let worldTimeWorkChain = Promise.resolve();
+
+/**
  * Handle follow-up actions when the official World time is changed
  * @param {number} worldTime      The new canonical World time.
- * @param {object} options        Options passed from the requesting client where the change was made
- * @param {string} userId         The ID of the User who advanced the time
+ * @param {number} dt             The time delta in seconds.
  */
-Hooks.on("updateWorldTime", async (worldTime, options) => {
-    //console.log(`updateWorldTime`, game.time.worldTime);
-    const _start = Date.now();
-
+Hooks.on("updateWorldTime", (worldTime, dt) => {
     // Ensure that this only runs for 1 user to we don't have multiple user attempting to
     // initiate actions. For simplicity we will limit it to the GM.
     if (game.user !== game.users.activeGM) return;
 
-    let deltaSeconds = parseInt(options || 0);
+    worldTimeWorkChain = worldTimeWorkChain
+        .then(() => _processWorldTimeUpdate(dt))
+        .catch((e) => console.error(`updateWorldTime processing failed: ${e.message}`, e));
+});
+
+async function _processWorldTimeUpdate(dt) {
+    //console.log(`updateWorldTime`, game.time.worldTime);
+    const _start = Date.now();
+
+    const deltaSeconds = parseInt(dt || 0);
     secondsSinceRecovery += deltaSeconds;
 
-    const multiplier = Math.floor(secondsSinceRecovery / 12);
-    secondsSinceRecovery = Math.max(0, secondsSinceRecovery - secondsSinceRecovery * multiplier);
-
-    // Charges and Body use days
-    const dt = new Date(worldTime * 1000);
-    dt.setHours(0);
-    dt.setMinutes(0);
-    dt.setSeconds(0);
-    dt.setMilliseconds(0);
+    // Recoveries occur every 12 seconds; bank any remainder toward the next advance.
+    const multiplier = Math.max(0, Math.floor(secondsSinceRecovery / 12));
+    secondsSinceRecovery = Math.max(0, secondsSinceRecovery - 12 * multiplier);
 
     await reRenderSheetsWithTemporyEffects();
 
     // All actors plus any unlinked actors in active scene
     const _actorCollection = Date.now();
     const actors = Array.from(game.actors);
+    const worldActorIds = new Set(actors.map((o) => o.id));
     const currentTokens = game.scenes.current?.tokens || [];
     for (const token of currentTokens) {
-        if (token.actor && (!token.actorLink || !actors.find((o) => o.id === token.actor.id))) {
+        if (token.actor && (!token.actorLink || !worldActorIds.has(token.actor.id))) {
             actors.push(token.actor);
         }
     }
     console.debug(`updateWorldTime.actorCollection took ${Date.now() - _actorCollection} ms`);
 
+    // Recovery only matters when 12+ seconds have accumulated; _outOfCombatRecovery
+    // keeps its own inCombat/automation gates.
+    const runRecovery = multiplier > 0;
+    let processedCount = 0;
     const _startExpire1 = {};
     for (const actor of actors) {
         try {
-            // Expire effects that expire on segment end
-            const _ee = Date.now();
-            await expireEffects(actor, "segment");
-            _startExpire1.ee = (_startExpire1.ee ?? 0) + (Date.now() - _ee);
+            // Most actors need nothing on a time tick.
+            const hasTempEffects = actorHasTemporaryEffects(actor);
+            if (!hasTempEffects && !runRecovery) continue;
+            processedCount++;
 
-            // Out of combat recovery.  When SimpleCalendar is used to advance time.
-            // This simple routine only handles increments of 12 seconds or more.
-            const _oocr = Date.now();
-            await _outOfCombatRecovery(actor, multiplier);
-            _startExpire1.oocr = (_startExpire1.oocr ?? 0) + (Date.now() - _oocr);
+            if (hasTempEffects) {
+                // Expire effects that expire on segment end
+                const _ee = Date.now();
+                await expireEffects(actor, "segment");
+                _startExpire1.ee = (_startExpire1.ee ?? 0) + (Date.now() - _ee);
+            }
 
-            // Expire continuing charges
-            const _ecc = Date.now();
-            await _expireContinuingCharges(actor);
-            _startExpire1.ecc = (_startExpire1.ecc ?? 0) + (Date.now() - _ecc);
+            if (runRecovery) {
+                // Out of combat recovery.  When SimpleCalendar is used to advance time.
+                // This simple routine only handles increments of 12 seconds or more.
+                const _oocr = Date.now();
+                await _outOfCombatRecovery(actor, multiplier);
+                _startExpire1.oocr = (_startExpire1.oocr ?? 0) + (Date.now() - _oocr);
+            }
+
+            if (hasTempEffects) {
+                // Expire continuing charges
+                const _ecc = Date.now();
+                await _expireContinuingCharges(actor);
+                _startExpire1.ecc = (_startExpire1.ecc ?? 0) + (Date.now() - _ecc);
+            }
         } catch (e) {
             console.error(e, actor, actor?.temporaryEffects[0]);
         }
     }
-    console.debug(`updateWorldTime.expireEffects took ${_startExpire1.ee} ms`);
-    console.debug(`updateWorldTime.outOfCombatRecovery took ${_startExpire1.oocr} ms`);
-    console.debug(`updateWorldTime.expireContinuingCharges took ${_startExpire1.ecc} ms`);
+    console.debug(`updateWorldTime processed ${processedCount}/${actors.length} actors`);
+    console.debug(`updateWorldTime.expireEffects took ${_startExpire1.ee ?? 0} ms`);
+    console.debug(`updateWorldTime.outOfCombatRecovery took ${_startExpire1.oocr ?? 0} ms`);
+    console.debug(`updateWorldTime.expireContinuingCharges took ${_startExpire1.ecc ?? 0} ms`);
 
     // If there are lots of actors updateWorldTime may result in performance issues.
     // Notify GM when this is a concern.
@@ -828,7 +861,7 @@ Hooks.on("updateWorldTime", async (worldTime, options) => {
     } else {
         console.debug(`updateWorldTime took ${deltaMs} ms`);
     }
-});
+}
 
 async function reRenderSheetsWithTemporyEffects() {
     try {
@@ -859,6 +892,7 @@ async function reRenderSheetsWithTemporyEffects() {
 }
 
 async function _expireContinuingCharges(actor) {
+    let needsRefresh = false;
     for (const aeWithCharges of actor.temporaryEffects.filter((o) =>
         o.parent instanceof HeroSystem6eItem ? o.parent.findModsByXmlid("CONTINUING") : false,
     )) {
@@ -869,9 +903,10 @@ async function _expireContinuingCharges(actor) {
         if (game.time.worldTime >= aeWithCharges.flags[game.system.id]?.startTime + aeWithCharges.duration.seconds) {
             await aeWithCharges.parent.toggle();
         } else {
-            if (game.ready) game[HEROSYS.module].effectPanel.refresh();
+            needsRefresh = true;
         }
     }
+    if (needsRefresh && game.ready) game[HEROSYS.module].effectPanel.refresh();
 }
 
 /**

--- a/module/testing/testing-main.mjs
+++ b/module/testing/testing-main.mjs
@@ -38,6 +38,7 @@ Hooks.on("quenchReady", async (quench) => {
         { registerActorCharacteristicTests },
         { registerAdjustmentFadeTests },
         { registerItemEditionTests },
+        { registerWorldTimeTests },
     ] = await Promise.all([
         import("./testing-automaton.mjs"),
         import("./testing-base.mjs"),
@@ -61,10 +62,10 @@ Hooks.on("quenchReady", async (quench) => {
         import("./testing-default-characteristics.mjs"),
         import("./testing-adjustment-fade.mjs"),
         import("./testing-item-edition.mjs"),
+        import("./testing-world-time.mjs"),
     ]);
 
     registerGlobalSetup(quench);
-
     registerAutomatonTests(quench);
     registerBaseTests(quench);
     registerCslTests(quench);
@@ -87,6 +88,7 @@ Hooks.on("quenchReady", async (quench) => {
     registerCombatTests(quench);
     registerAdjustmentFadeTests(quench);
     registerItemEditionTests(quench);
+    registerWorldTimeTests(quench);
 
     registerGlobalTeardown(quench);
 });

--- a/module/testing/testing-world-time.mjs
+++ b/module/testing/testing-world-time.mjs
@@ -1,0 +1,212 @@
+import { HEROSYS } from "../herosystem6e.mjs";
+
+/**
+ * Registers tests for the updateWorldTime pipeline: out-of-combat recovery (including
+ * banked remainder seconds), batched effect expiry with combined chat messages, and
+ * resilience against malformed or disabled temporary effects.
+ *
+ * @param {Object} quench - The external Quench module testing framework instance.
+ */
+export function registerWorldTimeTests(quench) {
+    quench.registerBatch(
+        `${game.system.id}.worldTime`,
+        (context) => {
+            const { describe, it, assert, before, after, beforeEach, afterEach } = context;
+
+            describe("World Time Recovery & Effect Expiry", function () {
+                // Recovery calibration steps world time second-by-second with settle waits.
+                this.timeout(60000);
+
+                let testActor = null;
+                let originalAutomation = null;
+
+                /**
+                 * Recovery and expiry writes are intentionally not awaited by the updateWorldTime
+                 * pipeline, so poll until the observable state lands.
+                 */
+                const settle = async (predicate, timeoutMs = 3000) => {
+                    const start = Date.now();
+                    while (Date.now() - start < timeoutMs) {
+                        if (predicate()) return true;
+                        await new Promise((resolve) => setTimeout(resolve, 50));
+                    }
+                    return predicate();
+                };
+
+                // Effects with no XMLID, statuses, or changes are swept as stale leftovers by
+                // expireEffects before their expiry is due; a no-op change keeps them alive.
+                const noopChange = { key: "system.characteristics.str.value", mode: 2, value: "0" };
+
+                before(async () => {
+                    originalAutomation = game.settings.get(HEROSYS.module, "automation");
+                    await game.settings.set(HEROSYS.module, "automation", "all");
+                });
+
+                after(async () => {
+                    await game.settings.set(HEROSYS.module, "automation", originalAutomation);
+                });
+
+                beforeEach(async () => {
+                    testActor = await Actor.create({
+                        name: "_Quench World Time Target",
+                        type: "pc",
+                        system: { is5e: false },
+                    });
+                });
+
+                afterEach(async () => {
+                    await testActor?.delete();
+                    testActor = null;
+                });
+
+                it("Should recover STUN/END every 12 seconds out of combat, banking remainder seconds", async function () {
+                    const rec = parseInt(testActor.system.characteristics.rec.value);
+                    assert.isAbove(rec, 0, "Test actor needs positive REC.");
+
+                    const stunMax = parseInt(testActor.system.characteristics.stun.max);
+                    const endMax = parseInt(testActor.system.characteristics.end.max);
+                    assert.isAtLeast(stunMax, 3 * rec + 2, "Test actor needs STUN headroom for 3 recoveries.");
+                    assert.isAtLeast(endMax, 3 * rec + 2, "Test actor needs END headroom for 3 recoveries.");
+
+                    await testActor.update({
+                        "system.characteristics.stun.value": 2,
+                        "system.characteristics.end.value": 2,
+                    });
+
+                    // The recovery accumulator is module-level state with an unknown remainder
+                    // banked from prior time advances. Step one second at a time until a recovery
+                    // lands; the bank is then at (or within a couple of seconds of) zero.
+                    let calibrated = false;
+                    for (let i = 0; i < 13 && !calibrated; i++) {
+                        await game.time.advance(1);
+                        calibrated = await settle(() => testActor.system.characteristics.stun.value > 2, 400);
+                    }
+                    assert.isTrue(calibrated, "Expected an out-of-combat recovery within 13 one-second advances.");
+
+                    const stunAfterCalibration = parseInt(testActor.system.characteristics.stun.value);
+                    const endAfterCalibration = parseInt(testActor.system.characteristics.end.value);
+
+                    // A single 25 second advance is two 12 second recoveries with 1 second banked.
+                    await game.time.advance(25);
+                    assert.isTrue(
+                        await settle(
+                            () => testActor.system.characteristics.stun.value === stunAfterCalibration + 2 * rec,
+                        ),
+                        `Expected exactly two recoveries (+${2 * rec} STUN) from a 25 second advance. ` +
+                            `STUN=${testActor.system.characteristics.stun.value} expected=${stunAfterCalibration + 2 * rec}`,
+                    );
+                    assert.equal(
+                        parseInt(testActor.system.characteristics.end.value),
+                        endAfterCalibration + 2 * rec,
+                        "Expected exactly two recoveries of END from a 25 second advance.",
+                    );
+
+                    // The banked second plus 11 more crosses the next 12 second boundary.
+                    await game.time.advance(11);
+                    assert.isTrue(
+                        await settle(
+                            () => testActor.system.characteristics.stun.value === stunAfterCalibration + 3 * rec,
+                        ),
+                        "Expected the banked remainder second to count toward the next recovery (1 banked + 11 = 12).",
+                    );
+                });
+
+                it("Should expire simultaneous effects in one batch with a single combined chat message", async function () {
+                    const startTime = game.time.worldTime;
+                    await testActor.createEmbeddedDocuments("ActiveEffect", [
+                        {
+                            name: "Quench Expiry Alpha",
+                            duration: { startTime, seconds: 5 },
+                            changes: [noopChange],
+                            flags: { [game.system.id]: { expiresOn: "segmentEnd", source: "Quench Test" } },
+                        },
+                        {
+                            name: "Quench Expiry Beta",
+                            duration: { startTime, seconds: 5 },
+                            changes: [noopChange],
+                            flags: { [game.system.id]: { expiresOn: "segmentEnd", source: "Quench Test" } },
+                        },
+                    ]);
+                    assert.equal(testActor.effects.size, 2, "Setup should add two temporary effects.");
+
+                    const priorMessageIds = new Set(game.messages.map((m) => m.id));
+
+                    await game.time.advance(7);
+
+                    assert.isTrue(
+                        await settle(() => testActor.effects.size === 0),
+                        "Expected both expired effects to be bulk deleted.",
+                    );
+                    await settle(() =>
+                        game.messages.some((m) => !priorMessageIds.has(m.id) && m.speaker?.actor === testActor.id),
+                    );
+
+                    const expiryMessages = game.messages.filter(
+                        (m) => !priorMessageIds.has(m.id) && m.speaker?.actor === testActor.id,
+                    );
+                    assert.equal(expiryMessages.length, 1, "Expected a single combined expiry chat message.");
+                    assert.include(expiryMessages[0].content, "Quench Expiry Alpha", "Combined message lists Alpha.");
+                    assert.include(expiryMessages[0].content, "Quench Expiry Beta", "Combined message lists Beta.");
+                });
+
+                it("Should expire and delete effects that lack system flags without throwing", async function () {
+                    const startTime = game.time.worldTime;
+                    await testActor.createEmbeddedDocuments("ActiveEffect", [
+                        {
+                            name: "Quench Malformed Effect",
+                            duration: { startTime, seconds: 5 },
+                            changes: [noopChange],
+                        },
+                    ]);
+
+                    const priorMessageIds = new Set(game.messages.map((m) => m.id));
+
+                    await game.time.advance(7);
+
+                    assert.isTrue(
+                        await settle(() => testActor.effects.size === 0),
+                        "Expected the flag-less effect to be deleted rather than crash expireEffects.",
+                    );
+                    await settle(() =>
+                        game.messages.some((m) => !priorMessageIds.has(m.id) && m.speaker?.actor === testActor.id),
+                    );
+
+                    const expiryMessage = game.messages.find(
+                        (m) => !priorMessageIds.has(m.id) && m.speaker?.actor === testActor.id,
+                    );
+                    assert.isOk(expiryMessage, "Expected an expiry chat message for the flag-less effect.");
+                    assert.include(expiryMessage.content, "an unknown source", "Missing source falls back gracefully.");
+                });
+
+                it("Should still expire effects on actors whose only temporary effect is disabled", async function () {
+                    const startTime = game.time.worldTime;
+                    await testActor.createEmbeddedDocuments("ActiveEffect", [
+                        {
+                            name: "Quench Disabled Effect",
+                            disabled: true,
+                            duration: { startTime, seconds: 5 },
+                            changes: [noopChange],
+                            flags: { [game.system.id]: { expiresOn: "segmentEnd", source: "Quench Test" } },
+                        },
+                    ]);
+
+                    // Disabled effects are excluded from core actor.temporaryEffects, so this actor
+                    // looks idle to a naive gate; the world-time pre-filter must still process it.
+                    assert.equal(
+                        testActor.temporaryEffects.length,
+                        0,
+                        "Core temporaryEffects should exclude the disabled effect (precondition).",
+                    );
+
+                    await game.time.advance(7);
+
+                    assert.isTrue(
+                        await settle(() => testActor.effects.size === 0),
+                        "Expected the disabled temporary effect to expire and be deleted.",
+                    );
+                });
+            });
+        },
+        { displayName: "HERO: World Time Recovery & Expiry" },
+    );
+}

--- a/module/utility/util.mjs
+++ b/module/utility/util.mjs
@@ -237,6 +237,37 @@ export async function expireEffects(actor, expiresOn) {
 
     const adjustmentChatMessages = [];
 
+    // Deletes are batched (one deleteEmbeddedDocuments per parent) and expiry messages
+    // combined into one ChatMessage per actor, to keep time ticks quick.
+    const pendingDeletes = new Map();
+    const markForDeletion = (ae) => {
+        if (!pendingDeletes.has(ae.parent)) pendingDeletes.set(ae.parent, new Set());
+        pendingDeletes.get(ae.parent).add(ae.id);
+    };
+    const isMarkedForDeletion = (ae) => pendingDeletes.get(ae.parent)?.has(ae.id) ?? false;
+    const expiredCardHtmls = [];
+    const flushPendingWork = async () => {
+        for (const [parent, aeIds] of pendingDeletes) {
+            // A concurrent pass (rapid time advances) or performAdjustment may have already
+            // deleted some of these; deleting a missing id throws and would abort the batch.
+            const ids = Array.from(aeIds).filter((id) => parent.effects.has(id));
+            try {
+                if (ids.length > 0) await parent.deleteEmbeddedDocuments("ActiveEffect", ids);
+            } catch (e) {
+                console.error(`Failed to bulk delete expired effects on ${parent.uuid}: ${e.message}`);
+            }
+        }
+        if (expiredCardHtmls.length > 0) {
+            await ChatMessage.create({
+                content: expiredCardHtmls.join("<br>"),
+                speaker: ChatMessage.getSpeaker({
+                    actor,
+                    token: tokenEducatedGuess({ actor }),
+                }),
+            });
+        }
+    };
+
     // TODO: Move remaining sanity checks to HeroValidation
     for (const ae of temporaryEffects) {
         // We are expecting expiresOn flag
@@ -253,6 +284,7 @@ export async function expireEffects(actor, expiresOn) {
 
         if (!expiresOn) {
             console.error(`${actor?.name}/${ae?.name} is missing expiresOn`, ae);
+            await flushPendingWork();
             return;
         }
 
@@ -261,6 +293,7 @@ export async function expireEffects(actor, expiresOn) {
         }
 
         if (expiresOn.includes("segment") && aeExpiresOn?.includes("turn") && actor.inCombat) {
+            await flushPendingWork();
             return;
         }
 
@@ -305,8 +338,7 @@ export async function expireEffects(actor, expiresOn) {
                     ui.notifications.warn(
                         `The originating item ${ae.origin} of adjustment ${ae.name} appears to have been deleted. Deleting adjustment's active effect.`,
                     );
-                    // TODO: bulk delete all AE's at once, then take a second pass for HeroValidation
-                    await ae.delete();
+                    markForDeletion(ae);
                     break;
                 }
 
@@ -330,9 +362,7 @@ export async function expireEffects(actor, expiresOn) {
                 });
 
                 if (bodyValue === bodyMax) {
-                    // TODO: one ChatMessage per actor
-                    // TODO: bulk delete all AE's at once, then take a second pass for HeroValidation
-                    await ae.delete();
+                    markForDeletion(ae);
                     break;
                 }
             } else {
@@ -348,19 +378,13 @@ export async function expireEffects(actor, expiresOn) {
                 // May need to revisit and make exception for statuses (like prone/recovery)
 
                 if (ae.parent instanceof HeroSystem6eActor) {
-                    const cardHtml = `${ae.name.replace(/\d+ segments remaining/, "")} from ${ae.flags[game.system.id].source} has expired.`;
-                    const chatData = {
-                        //author: game.user._id,
-                        content: cardHtml,
-                        speaker: ChatMessage.getSpeaker({
-                            actor,
-                            token: tokenEducatedGuess({ actor }),
-                        }),
-                    };
-                    // TODO: one ChatMessage per actor
-                    await ChatMessage.create(chatData);
-                    // TODO: bulk delete all AE's at once, then take a second pass for HeroValidation
-                    await ae.delete();
+                    // Effects created outside this system may lack our flags; a throw here would
+                    // abort combat turn events (skipping PostSegment12) and leave the AE undeletable.
+                    const source = ae.flags[game.system.id]?.source ?? "an unknown source";
+                    expiredCardHtmls.push(
+                        `${ae.name.replace(/\d+ segments remaining/, "")} from ${source} has expired.`,
+                    );
+                    markForDeletion(ae);
                 }
                 break;
             }
@@ -370,8 +394,7 @@ export async function expireEffects(actor, expiresOn) {
                 // Sanity delete
                 if (ae.flags[game.system.id]?.adjustmentActivePoints === 0) {
                     console.error(`Sanity deleting ${ae.name}. Shouldn't need to do this.`);
-                    // TODO: bulk delete all AE's at once, then take a second pass for HeroValidation
-                    await ae.delete();
+                    markForDeletion(ae);
                     break;
                 }
 
@@ -386,13 +409,17 @@ export async function expireEffects(actor, expiresOn) {
             }
         }
 
+        // Effects awaiting bulk deletion still report persisted=true; skip cleanup & validation.
+        if (isMarkedForDeletion(ae)) continue;
+
         // Sanity (or cleanup) delete
         if (ae.persisted && !ae.XMLID && ae.statuses.size === 0 && ae.changes.length === 0) {
             // What can this AE possibly be good for, likely a leftover from an old system rev.
             console.error(
                 `Deleted ${ae.parent?.parent?.name}/${ae.parent?.name}/${ae.name} as it has no XMLID, statuses, or changes.`,
             );
-            await ae.delete();
+            markForDeletion(ae);
+            continue;
         }
 
         // If temporary effect is still active, check heroValidation
@@ -449,6 +476,8 @@ export async function expireEffects(actor, expiresOn) {
     }
 
     //delete window.expireEffects[actor.id];
+
+    await flushPendingWork();
 
     await renderAdjustmentChatCards(adjustmentChatMessages);
 }

--- a/module/utility/util.mjs
+++ b/module/utility/util.mjs
@@ -264,6 +264,7 @@ export async function expireEffects(actor, expiresOn) {
                     actor,
                     token: tokenEducatedGuess({ actor }),
                 }),
+                whisper: whisperUserTargetsForActor(actor),
             });
         }
     };


### PR DESCRIPTION
Every world-time change — which combat's next-turn/next-round buttons trigger on essentially every click — walked all game.actors plus current-scene tokens and serially awaited effect expiry, out-of-combat recovery, and continuing-charge checks per actor. In medium worlds each combat click was O(all actors) with multiple DB round-trips, tripping the hook's own >100 ms self-diagnostic.
 
Three structural changes:
- Pre-filter: actors with no temporary effects are skipped entirely unless a 12-second recovery boundary was crossed. Measured on a 44-actor world: steady-state ticks now process 9/44 actors in ~17 ms; the only >100 ms tick left is the segment-12 crossing, which is real work (recovery for all actors + actual adjustment fades).
- Batched writes: expireEffects now bulk-deletes expired effects (one deleteEmbeddedDocuments per parent) and posts one combined expiry chat message per actor, resolving the five standing TODO: bulk delete all AE's at once / one ChatMessage per actor comments.
- Serialized processing: Foundry doesn't await async hook callbacks, so rapid time advances could overlap and double-process the same effects (does not exist in the EmbeddedCollection errors). Ticks now queue on a promise chain.
 
Bug fixes found along the way: the secondsSinceRecovery remainder was zeroed on multi-recovery advances (a 25 s advance lost its banked 1 s); effects lacking system flags (user-created AEs) crashed expireEffects before their own deletion, making them immortal and crash-looping every tick; the hook's 2nd parameter was named options but is actually the v13 dt delta.

New quench batch HERO: World Time Recovery & Expiry (4 tests) covers the pre-filter edge cases, remainder banking, batched expiry, and the flags-less-effect fix. Full suite passes (the two powers.validate() failures are pre-existing on main from the STRIKE & TRIP xml entries).